### PR TITLE
feat: background chats

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,8 @@
 - Save what you typed in the main chat input per chat (in localstorage or something, of course put limitations on size and frequency)
 - Continue chat on tool call validation errors (let the model know it made a mistake?)
 - Fix drawer shrinking and not reverting to original size when opening keyboard on mobile devices
-- Don't disable model selector when streaming (lol) but keep track of what model was used for a chat when switching between chats
 - Make persistence happen more often (like after tool calls etc too) to save progress better
 - Fix user's very first chat when localStorage is clear not showing up in the sidebar
 - "Unload" chats that aren't currently streaming
-- Use custom abort error for tools so the tool UI can show "Cancelled" instead of an error?
 - Kill ongoing stream on chat deletion
-- Introduced in 49d2f3417af8370dc6b0830a7c422c8a2f4aca3f: `stop` doesn't cause a tool to `output-error` anymore, so the tool remains in the `input-available` state, showing a loader even after the tool is cancelled. Related: https://github.com/vercel/ai/pull/7902, https://github.com/vercel/ai/releases/tag/ai%405.0.24
+- Introduced in 49d2f3417af8370dc6b0830a7c422c8a2f4aca3f: `stop` doesn't cause a tool to `output-error` anymore, so the tool remains in the `input-available` state, showing a loader even after the tool is cancelled. Related: https://github.com/vercel/ai/pull/7902, https://github.com/vercel/ai/releases/tag/ai%405.0.24/ So: Use custom abort error for tools so the tool UI can show "Cancelled" instead of an error? Attach onFinish listener to get the reason and update UI? Or something else?

--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -1,13 +1,17 @@
+import { type UseChatHelpers } from "@ai-sdk/react";
 import {
   lastAssistantMessageIsCompleteWithToolCalls,
+  type LanguageModel,
   type UIMessage,
 } from "ai";
-import React, {
-  type ReactNode,
+import {
+  memo,
   useCallback,
   useEffect,
   useMemo,
   useRef,
+  useState,
+  type ReactNode,
 } from "react";
 import { useLocation, useNavigate } from "react-router";
 
@@ -15,6 +19,7 @@ import { useModel } from "@/contexts/use-model/model-hooks";
 import { useChat } from "@/hooks/ai/useChat";
 import {
   createChat,
+  loadChat,
   loadChatData,
   saveChat,
   saveChatTitle,
@@ -31,107 +36,240 @@ import {
 
 const logger = getLogger(import.meta.url);
 
-interface ChatProviderProps {
-  children: ReactNode;
-  chatId: string | undefined;
-  initialMessages: UIMessage[];
-}
+type ChatInstanceCollection = Map<string, UseChatHelpers<UIMessage>>;
 
-export const ChatProvider: React.FC<ChatProviderProps> = ({
-  children,
-  chatId,
-  initialMessages,
-}) => {
-  const { currentModel } = useModel();
-  const navigate = useNavigate();
-  const location = useLocation();
+const useForceUpdate = () => {
+  const [, setTick] = useState(0);
+  return useCallback(() => setTick((t) => t + 1), []);
+};
 
-  const model = useMemo(() => currentModel.model, [currentModel.model]);
+/**
+ * A renderless component that encapsulates a single `useChat` hook instance.
+ * It reports its state up to the MultiChatProvider and handles its own side effects
+ * like saving messages and generating titles.
+ */
+const ChatInstance = memo(
+  ({
+    chatId,
+    model,
+    onInstanceUpdate,
+    onStatusChange,
+  }: {
+    chatId: string;
+    model: LanguageModel;
+    onInstanceUpdate: (id: string, instance: UseChatHelpers<UIMessage>) => void;
+    onStatusChange: (
+      id: string,
+      status: UseChatHelpers<UIMessage>["status"],
+    ) => void;
+  }) => {
+    const initialMessages = useMemo(() => loadChat(chatId), [chatId]);
 
-  // https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#usechat-changes
-  const {
-    messages,
-    status,
-    error,
-    sendMessage,
-    addToolResult,
-    regenerate,
-    resumeStream,
-    stop,
-    setMessages,
-  } = useChat(model, {
-    experimental_throttle: 250, // TODO: Allow customizing this in settings
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls, // Interesting note: true/false works here. Use for stop button?
-    id: chatId,
-    messages: initialMessages,
-  });
+    const chat = useChat(model, {
+      experimental_throttle: 250,
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+      id: chatId,
+      messages: initialMessages,
+    });
 
-  const hasMountedRef = useRef(false);
-
-  useEffect(() => {
-    if (!hasMountedRef.current) {
-      hasMountedRef.current = true;
-      return;
-    }
-    if (chatId && status !== "streaming" && messages.length > 0) {
-      try {
-        saveChat({ chatId, messages });
-
+    // Effect to save chat history and generate titles
+    useEffect(() => {
+      if (chat.status !== "streaming" && chat.messages.length > 0) {
+        saveChat({ chatId, messages: chat.messages });
         const chatData = loadChatData(chatId);
-        const hasUserMessage = messages.some((m) => m.role === "user");
-
+        const hasUserMessage = chat.messages.some((m) => m.role === "user");
         if (hasUserMessage && !chatData.titleState) {
           saveChatTitleState({ chatId, titleState: "generating" });
-          generateChatTitle(model, messages)
-            .then((generatedTitle) => {
-              saveChatTitle({ chatId, title: generatedTitle });
-            })
+          generateChatTitle(model, chat.messages)
+            .then((generatedTitle) =>
+              saveChatTitle({ chatId, title: generatedTitle }),
+            )
             .catch((error) => {
               logger.error("Failed to generate title for chat:", chatId, error);
               saveChatTitleState({ chatId, titleState: "error" });
             });
         }
-      } catch (error) {
-        logger.error("Failed to save chat or generate title:", chatId, error);
       }
-    }
-  }, [messages, status, chatId, model]);
+    }, [chat.messages, chat.status, chatId, model]);
 
+    // Report status changes to the parent provider
+    useEffect(() => {
+      onStatusChange(chatId, chat.status);
+    }, [chatId, chat.status, onStatusChange]);
+
+    // This effect syncs the latest chat state to the parent provider's ref.
+    // It runs on every render of ChatInstance. This is intentional and cheap,
+    // as ChatInstance is renderless. The parent provider will then decide
+    // whether a UI re-render is necessary based on focus.
+    useEffect(() => {
+      onInstanceUpdate(chatId, chat);
+    });
+
+    return null;
+  },
+);
+ChatInstance.displayName = "ChatInstance";
+
+/**
+ * Manages multiple chat sessions, keeping background chats alive while they are streaming
+ * and only forwarding the state of the currently focused chat to the UI.
+ */
+export const MultiChatProvider = ({
+  children,
+  currentChatId,
+}: {
+  children: ReactNode;
+  currentChatId: string | undefined;
+}) => {
+  const { currentModel } = useModel();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const forceUpdate = useForceUpdate();
+  const model = useMemo(() => currentModel.model, [currentModel.model]);
+
+  // Ref to store all active useChat instances
+  const chatInstancesRef = useRef<ChatInstanceCollection>(new Map());
+
+  // State to track which chat IDs need to be kept in memory
+  const [activeChatIds, setActiveChatIds] = useState<Set<string>>(() =>
+    currentChatId ? new Set([currentChatId]) : new Set(),
+  );
+
+  // State to trigger cleanup effect when any chat's status changes
+  const [lastStatusChange, setLastStatusChange] = useState({
+    id: "",
+    status: "",
+  });
+
+  // Callback for ChatInstance to register/update itself
+  const handleInstanceUpdate = useCallback(
+    (id: string, instance: UseChatHelpers<UIMessage> | null) => {
+      if (instance) {
+        chatInstancesRef.current.set(id, instance);
+      } else {
+        chatInstancesRef.current.delete(id);
+      }
+      // Only trigger a re-render of the provider if the updated
+      // chat is the one currently being displayed. Background chats
+      // will update their state in the ref without causing a UI update.
+      if (id === currentChatId) {
+        forceUpdate();
+      }
+    },
+    [currentChatId, forceUpdate],
+  );
+
+  // Callback for ChatInstance to report status changes
+  const handleStatusChange = useCallback((id: string, status: string) => {
+    setLastStatusChange({ id, status });
+  }, []);
+
+  // Effect to manage which chats are active (focused or streaming in background)
   useEffect(() => {
-    const pendingState = location.state?.pendingMessage;
-    if (pendingState && status === "ready") {
-      navigate(location.pathname, { replace: true, state: {} });
-      const { message, options } = pendingState;
-      sendMessage(message, options);
+    const newActiveIds = new Set<string>();
+    if (currentChatId) {
+      newActiveIds.add(currentChatId);
     }
-  }, [location.state, location.pathname, navigate, status, sendMessage]);
 
-  const sendMessageWrapper = useCallback(
-    (
-      message: Parameters<typeof sendMessage>[0],
-      options?: Parameters<typeof sendMessage>[1],
-    ): Promise<void> => {
-      if (chatId) {
-        return sendMessage(message, options);
+    chatInstancesRef.current.forEach((instance, id) => {
+      const isBusy =
+        instance.status === "streaming" || instance.status === "submitted";
+      if (isBusy) {
+        newActiveIds.add(id);
       }
+    });
 
+    setActiveChatIds((prev) => {
+      if (
+        prev.size === newActiveIds.size &&
+        [...prev].every((id) => newActiveIds.has(id))
+      ) {
+        return prev;
+      }
+      logger.verbose("Updating active chat IDs", {
+        new: Array.from(newActiveIds),
+      });
+      return newActiveIds;
+    });
+  }, [currentChatId, lastStatusChange]);
+
+  // Default `useChat` instance for the "new chat" screen
+  const defaultChat = useChat(model);
+
+  // Wrapper for sending a message from the "new chat" screen
+  const handleNewChatSubmit = useCallback(
+    (
+      message: Parameters<typeof defaultChat.sendMessage>[0],
+      options?: Parameters<typeof defaultChat.sendMessage>[1],
+    ) => {
       const newChatId = createChat();
-
       navigate(`/chat/${newChatId}`, {
         replace: true,
         state: { pendingMessage: { message, options } },
       });
-
       return Promise.resolve();
     },
-    [chatId, navigate, sendMessage],
+    [navigate, defaultChat.sendMessage],
   );
 
-  const statusValue = useMemo(() => ({ status, error }), [status, error]);
+  // Select the currently focused chat instance
+  const isNewChat = !currentChatId;
+  const focusedChatInstance = currentChatId
+    ? chatInstancesRef.current.get(currentChatId)
+    : undefined;
+
+  // Handle submitting a message passed via navigation state
+  useEffect(() => {
+    const pendingState = location.state?.pendingMessage;
+    if (
+      pendingState &&
+      focusedChatInstance?.status === "ready" &&
+      currentChatId
+    ) {
+      const instance = chatInstancesRef.current.get(currentChatId);
+      if (instance?.sendMessage) {
+        navigate(location.pathname, { replace: true, state: {} });
+        const { message, options } = pendingState;
+        instance.sendMessage(message, options);
+      }
+    }
+  }, [
+    location.state,
+    location.pathname,
+    navigate,
+    focusedChatInstance?.status,
+    currentChatId,
+  ]);
+
+  // Memoize context values to prevent unnecessary re-renders
+  const messages = focusedChatInstance?.messages ?? defaultChat.messages;
+
+  const statusValue = useMemo(
+    () => ({
+      status: focusedChatInstance?.status ?? defaultChat.status,
+      error: focusedChatInstance?.error ?? defaultChat.error,
+    }),
+    [
+      focusedChatInstance?.status,
+      focusedChatInstance?.error,
+      defaultChat.status,
+      defaultChat.error,
+    ],
+  );
+
+  const instanceForFunctions = focusedChatInstance || defaultChat;
+  const {
+    addToolResult,
+    regenerate,
+    resumeStream,
+    stop,
+    setMessages,
+    sendMessage,
+  } = instanceForFunctions;
 
   const functionsValue = useMemo(
     () => ({
-      sendMessage: sendMessageWrapper,
+      sendMessage: isNewChat ? handleNewChatSubmit : sendMessage,
       addToolResult,
       regenerate,
       resumeStream,
@@ -139,7 +277,9 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
       setMessages,
     }),
     [
-      sendMessageWrapper,
+      isNewChat,
+      handleNewChatSubmit,
+      sendMessage,
       addToolResult,
       regenerate,
       resumeStream,
@@ -149,12 +289,23 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   );
 
   return (
-    <ChatMessagesContext.Provider value={messages}>
-      <ChatStatusContext.Provider value={statusValue}>
-        <ChatFunctionsContext.Provider value={functionsValue}>
-          {children}
-        </ChatFunctionsContext.Provider>
-      </ChatStatusContext.Provider>
-    </ChatMessagesContext.Provider>
+    <>
+      {Array.from(activeChatIds).map((id) => (
+        <ChatInstance
+          key={id}
+          chatId={id}
+          model={model}
+          onInstanceUpdate={handleInstanceUpdate}
+          onStatusChange={handleStatusChange}
+        />
+      ))}
+      <ChatMessagesContext.Provider value={messages}>
+        <ChatStatusContext.Provider value={statusValue}>
+          <ChatFunctionsContext.Provider value={functionsValue}>
+            {children}
+          </ChatFunctionsContext.Provider>
+        </ChatStatusContext.Provider>
+      </ChatMessagesContext.Provider>
+    </>
   );
 };

--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -48,6 +48,7 @@ export const MultiChatProvider = ({
     currentModel: defaultModelForNewChats,
     setModel: setDefaultModelForNewChats,
   } = useModel();
+  if (!defaultModelForNewChats === undefined) throw new Error("");
   const navigate = useNavigate();
   const location = useLocation();
   const forceUpdate = useForceUpdate();

--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -1,17 +1,17 @@
 import { type UseChatHelpers } from "@ai-sdk/react";
 import {
-  lastAssistantMessageIsCompleteWithToolCalls,
   type LanguageModel,
+  lastAssistantMessageIsCompleteWithToolCalls,
   type UIMessage,
 } from "ai";
 import {
   memo,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type ReactNode,
 } from "react";
 import { useLocation, useNavigate } from "react-router";
 
@@ -209,6 +209,7 @@ export const MultiChatProvider = ({
       });
       return Promise.resolve();
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [navigate, defaultChat.sendMessage],
   );
 

--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -10,9 +10,11 @@ import {
 } from "react";
 import { useLocation, useNavigate } from "react-router";
 
+import { ModelContext } from "@/contexts/use-model/model-contexts";
 import { useModel } from "@/contexts/use-model/model-hooks";
 import { useChat } from "@/hooks/ai/useChat";
-import { createChat } from "@/lib/ai/persistence";
+import { getModelById, type ModelConfig } from "@/lib/ai/models";
+import { createChat, loadChatData, saveChatModel } from "@/lib/ai/persistence";
 import { getLogger } from "@/lib/logger";
 
 import {
@@ -42,11 +44,13 @@ export const MultiChatProvider = ({
   children: ReactNode;
   currentChatId: string | undefined;
 }) => {
-  const { currentModel } = useModel();
+  const {
+    currentModel: defaultModelForNewChats,
+    setModel: setDefaultModelForNewChats,
+  } = useModel();
   const navigate = useNavigate();
   const location = useLocation();
   const forceUpdate = useForceUpdate();
-  const model = useMemo(() => currentModel.model, [currentModel.model]);
 
   // Ref to store all active useChat instances
   const chatInstancesRef = useRef<ChatInstanceCollection>(new Map());
@@ -61,6 +65,54 @@ export const MultiChatProvider = ({
     id: "",
     status: "",
   });
+
+  // Helper to get the model for a given chat ID, with fallback
+  const getModelForChat = useCallback(
+    (chatId: string | undefined): ModelConfig => {
+      if (chatId) {
+        const chatData = loadChatData(chatId);
+        if (chatData.modelId) {
+          const chatModel = getModelById(chatData.modelId);
+          if (chatModel) {
+            return chatModel;
+          }
+        }
+      }
+      // Fallback for new chat or chat with no/invalid model
+      return defaultModelForNewChats;
+    },
+    [defaultModelForNewChats],
+  );
+
+  // The model for the currently focused chat/UI
+  const focusedModel = useMemo(
+    () => getModelForChat(currentChatId),
+    [currentChatId, getModelForChat],
+  );
+
+  // A new setModel function that handles both new and existing chats
+  const setModelForContext = useCallback(
+    (modelId: string) => {
+      if (currentChatId) {
+        // Update the model for the specific chat we're viewing
+        saveChatModel({ chatId: currentChatId, modelId });
+        forceUpdate(); // Re-render to update focusedModel and ChatInstance props
+      } else {
+        // We are on a "new chat" page, update the default model for new chats
+        setDefaultModelForNewChats(modelId);
+      }
+    },
+    [currentChatId, setDefaultModelForNewChats, forceUpdate],
+  );
+
+  // The context value to provide to UI components like ModelSelector
+  const modelContextValue = useMemo(
+    () => ({
+      currentModel: focusedModel,
+      setModel: setModelForContext,
+    }),
+    [focusedModel, setModelForContext],
+  );
 
   // Callback for ChatInstance to register/update itself
   const handleInstanceUpdate = useCallback(
@@ -115,7 +167,7 @@ export const MultiChatProvider = ({
   }, [currentChatId, lastStatusChange]);
 
   // Default `useChat` instance for the "new chat" screen
-  const defaultChat = useChat(model);
+  const defaultChat = useChat(defaultModelForNewChats.model);
 
   // Wrapper for sending a message from the "new chat" screen
   const handleNewChatSubmit = useCallback(
@@ -123,7 +175,7 @@ export const MultiChatProvider = ({
       message: Parameters<typeof defaultChat.sendMessage>[0],
       options?: Parameters<typeof defaultChat.sendMessage>[1],
     ) => {
-      const newChatId = createChat();
+      const newChatId = createChat(focusedModel.id);
       navigate(`/chat/${newChatId}`, {
         replace: true,
         state: { pendingMessage: { message, options } },
@@ -131,7 +183,7 @@ export const MultiChatProvider = ({
       return Promise.resolve();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [navigate, defaultChat.sendMessage],
+    [navigate, defaultChat.sendMessage, focusedModel.id],
   );
 
   // Select the currently focused chat instance
@@ -211,16 +263,19 @@ export const MultiChatProvider = ({
   );
 
   return (
-    <>
-      {Array.from(activeChatIds).map((id) => (
-        <ChatInstance
-          key={id}
-          chatId={id}
-          model={model}
-          onInstanceUpdate={handleInstanceUpdate}
-          onStatusChange={handleStatusChange}
-        />
-      ))}
+    <ModelContext.Provider value={modelContextValue}>
+      {Array.from(activeChatIds).map((id) => {
+        const chatModel = getModelForChat(id);
+        return (
+          <ChatInstance
+            key={id}
+            chatId={id}
+            model={chatModel.model}
+            onInstanceUpdate={handleInstanceUpdate}
+            onStatusChange={handleStatusChange}
+          />
+        );
+      })}
       <ChatMessagesContext.Provider value={messages}>
         <ChatStatusContext.Provider value={statusValue}>
           <ChatFunctionsContext.Provider value={functionsValue}>
@@ -228,6 +283,6 @@ export const MultiChatProvider = ({
           </ChatFunctionsContext.Provider>
         </ChatStatusContext.Provider>
       </ChatMessagesContext.Provider>
-    </>
+    </ModelContext.Provider>
   );
 };

--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -1,11 +1,6 @@
 import { type UseChatHelpers } from "@ai-sdk/react";
+import { type UIMessage } from "ai";
 import {
-  type LanguageModel,
-  lastAssistantMessageIsCompleteWithToolCalls,
-  type UIMessage,
-} from "ai";
-import {
-  memo,
   type ReactNode,
   useCallback,
   useEffect,
@@ -17,15 +12,7 @@ import { useLocation, useNavigate } from "react-router";
 
 import { useModel } from "@/contexts/use-model/model-hooks";
 import { useChat } from "@/hooks/ai/useChat";
-import {
-  createChat,
-  loadChat,
-  loadChatData,
-  saveChat,
-  saveChatTitle,
-  saveChatTitleState,
-} from "@/lib/ai/persistence";
-import { generateChatTitle } from "@/lib/ai/title-generator";
+import { createChat } from "@/lib/ai/persistence";
 import { getLogger } from "@/lib/logger";
 
 import {
@@ -33,6 +20,7 @@ import {
   ChatMessagesContext,
   ChatStatusContext,
 } from "./chat-contexts";
+import { ChatInstance } from "./chat-instance";
 
 const logger = getLogger(import.meta.url);
 
@@ -42,73 +30,6 @@ const useForceUpdate = () => {
   const [, setTick] = useState(0);
   return useCallback(() => setTick((t) => t + 1), []);
 };
-
-/**
- * A renderless component that encapsulates a single `useChat` hook instance.
- * It reports its state up to the MultiChatProvider and handles its own side effects
- * like saving messages and generating titles.
- */
-const ChatInstance = memo(
-  ({
-    chatId,
-    model,
-    onInstanceUpdate,
-    onStatusChange,
-  }: {
-    chatId: string;
-    model: LanguageModel;
-    onInstanceUpdate: (id: string, instance: UseChatHelpers<UIMessage>) => void;
-    onStatusChange: (
-      id: string,
-      status: UseChatHelpers<UIMessage>["status"],
-    ) => void;
-  }) => {
-    const initialMessages = useMemo(() => loadChat(chatId), [chatId]);
-
-    const chat = useChat(model, {
-      experimental_throttle: 250,
-      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-      id: chatId,
-      messages: initialMessages,
-    });
-
-    // Effect to save chat history and generate titles
-    useEffect(() => {
-      if (chat.status !== "streaming" && chat.messages.length > 0) {
-        saveChat({ chatId, messages: chat.messages });
-        const chatData = loadChatData(chatId);
-        const hasUserMessage = chat.messages.some((m) => m.role === "user");
-        if (hasUserMessage && !chatData.titleState) {
-          saveChatTitleState({ chatId, titleState: "generating" });
-          generateChatTitle(model, chat.messages)
-            .then((generatedTitle) =>
-              saveChatTitle({ chatId, title: generatedTitle }),
-            )
-            .catch((error) => {
-              logger.error("Failed to generate title for chat:", chatId, error);
-              saveChatTitleState({ chatId, titleState: "error" });
-            });
-        }
-      }
-    }, [chat.messages, chat.status, chatId, model]);
-
-    // Report status changes to the parent provider
-    useEffect(() => {
-      onStatusChange(chatId, chat.status);
-    }, [chatId, chat.status, onStatusChange]);
-
-    // This effect syncs the latest chat state to the parent provider's ref.
-    // It runs on every render of ChatInstance. This is intentional and cheap,
-    // as ChatInstance is renderless. The parent provider will then decide
-    // whether a UI re-render is necessary based on focus.
-    useEffect(() => {
-      onInstanceUpdate(chatId, chat);
-    });
-
-    return null;
-  },
-);
-ChatInstance.displayName = "ChatInstance";
 
 /**
  * Manages multiple chat sessions, keeping background chats alive while they are streaming

--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -48,7 +48,6 @@ export const MultiChatProvider = ({
     currentModel: defaultModelForNewChats,
     setModel: setDefaultModelForNewChats,
   } = useModel();
-  if (!defaultModelForNewChats === undefined) throw new Error("");
   const navigate = useNavigate();
   const location = useLocation();
   const forceUpdate = useForceUpdate();

--- a/src/contexts/use-chat/chat-instance.tsx
+++ b/src/contexts/use-chat/chat-instance.tsx
@@ -1,0 +1,87 @@
+import { type UseChatHelpers } from "@ai-sdk/react";
+import {
+  type LanguageModel,
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type UIMessage,
+} from "ai";
+import { memo, useEffect, useMemo } from "react";
+
+import { useChat } from "@/hooks/ai/useChat";
+import {
+  loadChat,
+  loadChatData,
+  saveChat,
+  saveChatTitle,
+  saveChatTitleState,
+} from "@/lib/ai/persistence";
+import { generateChatTitle } from "@/lib/ai/title-generator";
+import { getLogger } from "@/lib/logger";
+
+const logger = getLogger(import.meta.url);
+
+/**
+ * A renderless component that encapsulates a single `useChat` hook instance.
+ * It reports its state up to the MultiChatProvider and handles its own side effects
+ * like saving messages and generating titles.
+ */
+export const ChatInstance = memo(
+  ({
+    chatId,
+    model,
+    onInstanceUpdate,
+    onStatusChange,
+  }: {
+    chatId: string;
+    model: LanguageModel;
+    onInstanceUpdate: (id: string, instance: UseChatHelpers<UIMessage>) => void;
+    onStatusChange: (
+      id: string,
+      status: UseChatHelpers<UIMessage>["status"],
+    ) => void;
+  }) => {
+    const initialMessages = useMemo(() => loadChat(chatId), [chatId]);
+
+    const chat = useChat(model, {
+      experimental_throttle: 250, // TODO: Allow user to configure this
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls, // TODO: Investigate this more as a "stop when done with tool" option. You can set this to true or false.
+      id: chatId,
+      messages: initialMessages,
+    });
+
+    // Effect to save chat history and generate titles
+    useEffect(() => {
+      if (chat.status !== "streaming" && chat.messages.length > 0) {
+        saveChat({ chatId, messages: chat.messages });
+        const chatData = loadChatData(chatId);
+        const hasUserMessage = chat.messages.some((m) => m.role === "user");
+        if (hasUserMessage && !chatData.titleState) {
+          saveChatTitleState({ chatId, titleState: "generating" });
+          generateChatTitle(model, chat.messages)
+            .then((generatedTitle) =>
+              saveChatTitle({ chatId, title: generatedTitle }),
+            )
+            .catch((error) => {
+              logger.error("Failed to generate title for chat:", chatId, error);
+              saveChatTitleState({ chatId, titleState: "error" });
+            });
+        }
+      }
+    }, [chat.messages, chat.status, chatId, model]);
+
+    // Report status changes to the parent provider
+    useEffect(() => {
+      onStatusChange(chatId, chat.status);
+    }, [chatId, chat.status, onStatusChange]);
+
+    // This effect syncs the latest chat state to the parent provider's ref.
+    // It runs on every render of ChatInstance. This is intentional and cheap,
+    // as ChatInstance is renderless. The parent provider will then decide
+    // whether a UI re-render is necessary based on focus.
+    useEffect(() => {
+      onInstanceUpdate(chatId, chat);
+    });
+
+    return null;
+  },
+);
+ChatInstance.displayName = "ChatInstance";

--- a/src/contexts/use-model/model-context.tsx
+++ b/src/contexts/use-model/model-context.tsx
@@ -5,6 +5,7 @@ import {
   getModelById,
   type ModelConfig,
 } from "@/lib/ai/models";
+import { getNewChatModelId, saveNewChatModelId } from "@/lib/ai/persistence";
 
 import { ModelContext } from "./model-contexts";
 
@@ -20,7 +21,7 @@ interface ModelProviderProps {
 export const ModelProvider: React.FC<ModelProviderProps> = ({ children }) => {
   const [currentModel, setCurrentModel] = useState<ModelConfig>(() => {
     // Try to load from localStorage, fallback to default
-    const savedModelId = localStorage.getItem("selected-model-id");
+    const savedModelId = getNewChatModelId();
     if (savedModelId) {
       const savedModel = getModelById(savedModelId);
       if (savedModel) {
@@ -34,7 +35,7 @@ export const ModelProvider: React.FC<ModelProviderProps> = ({ children }) => {
     const model = getModelById(modelId);
     if (model) {
       setCurrentModel(model);
-      localStorage.setItem("selected-model-id", modelId);
+      saveNewChatModelId(modelId);
     }
   }, []);
 

--- a/src/lib/ai/persistence/index.ts
+++ b/src/lib/ai/persistence/index.ts
@@ -4,6 +4,7 @@ import { generateId } from "ai";
 import { getLogger } from "../../logger";
 
 const CHAT_IDS_KEY = "chat-ids";
+const NEW_CHAT_MODEL_ID_KEY = "new-chat-model-id";
 
 const logger = getLogger(import.meta.url);
 
@@ -11,6 +12,24 @@ export interface ChatData {
   messages: UIMessage[];
   title: string;
   titleState?: "generating" | "generated" | "error";
+  modelId?: string;
+}
+
+export function getNewChatModelId(): string | null {
+  try {
+    return localStorage.getItem(NEW_CHAT_MODEL_ID_KEY);
+  } catch (error) {
+    logger.error("Failed to get new chat model ID from localStorage", error);
+    return null;
+  }
+}
+
+export function saveNewChatModelId(modelId: string): void {
+  try {
+    localStorage.setItem(NEW_CHAT_MODEL_ID_KEY, modelId);
+  } catch (error) {
+    logger.error("Failed to save new chat model ID to localStorage", error);
+  }
 }
 
 function getChatKey(id: string): string {
@@ -35,7 +54,7 @@ function saveChatIds(ids: string[]): void {
   }
 }
 
-export function createChat(): string {
+export function createChat(modelId: string): string {
   const id = generateId();
   try {
     const chatKey = getChatKey(id);
@@ -43,6 +62,7 @@ export function createChat(): string {
       messages: [],
       title: "New chat",
       titleState: undefined,
+      modelId,
     };
     localStorage.setItem(chatKey, JSON.stringify(chatData));
     const currentIds = listChatIds();
@@ -96,6 +116,27 @@ export function saveChat({
     localStorage.setItem(chatKey, content);
   } catch (error) {
     logger.error(`Failed to save chat ${chatId} to localStorage`, error);
+  }
+}
+
+export function saveChatModel({
+  chatId,
+  modelId,
+}: {
+  chatId: string;
+  modelId: string;
+}): void {
+  try {
+    const chatKey = getChatKey(chatId);
+    const existingData = loadChatData(chatId);
+    const chatData: ChatData = {
+      ...existingData,
+      modelId,
+    };
+    const content = JSON.stringify(chatData);
+    localStorage.setItem(chatKey, content);
+  } catch (error) {
+    logger.error(`Failed to save chat model ${chatId} to localStorage`, error);
   }
 }
 

--- a/src/routes/chat/index.tsx
+++ b/src/routes/chat/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useRef } from "react";
 import { useParams } from "react-router";
 
 import {
@@ -10,9 +10,8 @@ import { NoMessagesGreeting } from "@/components/a1/empty-states/no-messages";
 import { MainChatInput } from "@/components/a1/input/main-chat-input";
 import { MessageParts } from "@/components/a1/messages";
 import { Sidebar } from "@/components/a1/sidebar";
-import { ChatProvider } from "@/contexts/use-chat/chat-context";
+import { MultiChatProvider } from "@/contexts/use-chat/chat-context";
 import { useChatMessages } from "@/contexts/use-chat/chat-hooks";
-import { loadChat } from "@/lib/ai/persistence";
 import { cn } from "@/lib/utils";
 
 const ChatInterface = ({ chatId }: { chatId: string | undefined }) => {
@@ -64,22 +63,10 @@ const ChatInterface = ({ chatId }: { chatId: string | undefined }) => {
 function ChatRoute() {
   const { id } = useParams<{ id: string }>();
 
-  const initialMessages = useMemo(() => {
-    if (id) {
-      try {
-        return loadChat(id);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (_error) {
-        return [];
-      }
-    }
-    return [];
-  }, [id]);
-
   return (
-    <ChatProvider chatId={id} initialMessages={initialMessages}>
+    <MultiChatProvider currentChatId={id}>
       <ChatInterface chatId={id} />
-    </ChatProvider>
+    </MultiChatProvider>
   );
 }
 


### PR DESCRIPTION
- [x] Allow chats to run in the background (so you can have more than one chat streaming at once)
- [x] Intelligently unload chats when they become inactive
- [x] Persist model per-chat and the default for starting new chats


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-chat experience: multiple chats stay active and can stream in the background.
  * Per-chat model selection persisted; default model applies to new chats.
  * Automatic chat title generation after your first message.

* **Improvements**
  * Smoother switching between chats with fewer UI re-renders.
  * Pending messages reliably delivered to the correct chat after navigation.
  * More robust persistence for chat metadata and model preferences.

* **Chores**
  * Updated persistence and model-selection behavior to support per-chat models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->