### PR TITLE
feat: floating main chat input setting

### DIFF
--- a/src/components/a1/input/main-chat-input.tsx
+++ b/src/components/a1/input/main-chat-input.tsx
@@ -29,12 +29,14 @@ import useMobileDetection from "@/hooks/use-mobile-detection";
 import { useTheme } from "@/hooks/use-theme";
 import { chatIdsAtom } from "@/lib/jotai/atoms";
 import {
+  inputStyleAtom,
   markdownHighlightingAtom,
   stopButtonBehaviorAtom,
   submitKeyAtom,
 } from "@/lib/jotai/settings-atoms";
 import { kbdRegistry } from "@/lib/kbd-registry";
 import { getLogger } from "@/lib/logger";
+import { cn } from "@/lib/utils";
 
 import { Attachments } from "./attachments";
 import { MainInputErrorSection } from "./error-section";
@@ -83,6 +85,7 @@ export const MainChatInput = ({
   const markdownHighlighting = useAtomValue(markdownHighlightingAtom);
   const stopButtonBehavior = useAtomValue(stopButtonBehaviorAtom);
   const submitKey = useAtomValue(submitKeyAtom);
+  const inputStyle = useAtomValue(inputStyleAtom);
   const { loadChat } = usePersistence();
   const chatIds = useAtomValue(chatIdsAtom);
   const isMobile = useMobileDetection({
@@ -358,8 +361,10 @@ export const MainChatInput = ({
     [addFiles, handleChatDrop],
   );
 
+  const isFloating = inputStyle === "floating";
+
   return (
-    <div className="px-0 md:px-2">
+    <div className={cn(isFloating ? "px-2 pb-2" : "px-0 md:px-2")}>
       <MainInputErrorSection onRetry={onScrollNeededAction} />
       <MainInputIncompleteSection onRetry={onScrollNeededAction} />
       <form
@@ -369,10 +374,20 @@ export const MainChatInput = ({
         onDragLeave={handleDragLeave}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
-        className="bg-secondary border-input focus-within:border-ring focus-within:ring-ring/50 relative flex w-full flex-col rounded-none border-0 border-t pt-2 pr-2 md:rounded-md md:rounded-b-none md:border md:border-b-0 md:focus-within:ring-[3px]"
+        className={cn(
+          "bg-secondary border-input focus-within:border-ring focus-within:ring-ring/50 relative flex w-full flex-col pt-2 pr-2",
+          isFloating
+            ? "rounded-md border focus-within:ring-[3px]"
+            : "rounded-none border-0 border-t md:rounded-md md:rounded-b-none md:border md:border-b-0 md:focus-within:ring-[3px]",
+        )}
       >
         {isDragging && (
-          <div className="border-primary bg-background/80 absolute inset-0 z-20 flex items-center justify-center rounded-md rounded-b-none border-2 border-dashed backdrop-blur-sm">
+          <div
+            className={cn(
+              "border-primary bg-background/80 absolute inset-0 z-20 flex items-center justify-center border-2 border-dashed backdrop-blur-sm",
+              isFloating ? "rounded-md" : "rounded-md rounded-b-none",
+            )}
+          >
             <p className="text-primary text-lg font-semibold">
               Drop files or chats to attach
             </p>
@@ -469,7 +484,12 @@ export const MainChatInput = ({
             }}
           />
         </div>
-        <div className="bg-secondary dark:bg-secondary flex items-center justify-between rounded-t-none rounded-b-md p-2 pr-0">
+        <div
+          className={cn(
+            "bg-secondary dark:bg-secondary flex items-center justify-between p-2 pr-0",
+            isFloating ? "rounded-b-md" : "rounded-t-none rounded-b-md",
+          )}
+        >
           <div className="relative">
             <Tooltip>
               <TooltipTrigger asChild>

--- a/src/lib/jotai/settings-atoms.ts
+++ b/src/lib/jotai/settings-atoms.ts
@@ -4,6 +4,7 @@ import {
   type ColorThemeOption,
   DEFAULT_SETTINGS,
   type FontOption,
+  type InputStyleOption,
   type MarkdownRenderingOption,
   type McpServerConfig,
   type MessageActionRowOption,
@@ -43,6 +44,11 @@ export const markdownRenderingAtom = createSettingAtom<MarkdownRenderingOption>(
 export const submitKeyAtom = createSettingAtom<SubmitKeyOption>(
   "SUBMIT_KEY",
   DEFAULT_SETTINGS.SUBMIT_KEY,
+);
+
+export const inputStyleAtom = createSettingAtom<InputStyleOption>(
+  "INPUT_STYLE",
+  DEFAULT_SETTINGS.INPUT_STYLE,
 );
 
 export const maxCodeblockCharsAtom = createSettingAtom(

--- a/src/lib/settings/reset-settings.ts
+++ b/src/lib/settings/reset-settings.ts
@@ -13,6 +13,7 @@ import {
   experimentalThrottleEnabledAtom,
   experimentalThrottleValueAtom,
   fontAtom,
+  inputStyleAtom,
   markdownHighlightingAtom,
   markdownRenderingAtom,
   maxCodeblockCharsAtom,
@@ -47,6 +48,7 @@ export function resetAllSettings(): void {
   store.set(markdownHighlightingAtom, RESET);
   store.set(markdownRenderingAtom, RESET);
   store.set(submitKeyAtom, RESET);
+  store.set(inputStyleAtom, RESET);
   store.set(maxCodeblockCharsAtom, RESET);
   store.set(maxMessageLengthAtom, RESET);
   store.set(maxToolResultCharsAtom, RESET);
@@ -91,6 +93,9 @@ export function resetSetting(key: keyof DefaultSettings): void {
       break;
     case "SUBMIT_KEY":
       store.set(submitKeyAtom, RESET);
+      break;
+    case "INPUT_STYLE":
+      store.set(inputStyleAtom, RESET);
       break;
     case "MAX_CODEBLOCK_CHARS":
       store.set(maxCodeblockCharsAtom, RESET);

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -18,6 +18,7 @@ export type TextScaleOption = "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
 export type NotificationOption = "always" | "when-unfocused" | "never";
 export type StopButtonBehaviorOption = "at-stopping-point" | "immediate";
 export type MessageActionRowOption = "hover" | "always" | "never";
+export type InputStyleOption = "docked" | "floating";
 
 export type TitleGenerationMethodOption =
   | "ai"
@@ -83,6 +84,7 @@ export interface DefaultSettings {
   MARKDOWN_HIGHLIGHTING: boolean;
   MARKDOWN_RENDERING: MarkdownRenderingOption;
   SUBMIT_KEY: SubmitKeyOption;
+  INPUT_STYLE: InputStyleOption;
   MAX_CODEBLOCK_CHARS: number;
   MAX_MESSAGE_LENGTH: number;
   MAX_TOOL_RESULT_CHARS: number;
@@ -117,6 +119,7 @@ export const DEFAULT_SETTINGS: DefaultSettings = {
   MARKDOWN_HIGHLIGHTING: true,
   MARKDOWN_RENDERING: "both",
   SUBMIT_KEY: "enter",
+  INPUT_STYLE: "docked",
   MAX_CODEBLOCK_CHARS: 10000,
   MAX_MESSAGE_LENGTH: 50000,
   MAX_TOOL_RESULT_CHARS: 15000,

--- a/src/routes/settings/sections/editor.tsx
+++ b/src/routes/settings/sections/editor.tsx
@@ -13,23 +13,30 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
+  inputStyleAtom,
   markdownHighlightingAtom,
   regenerateOnSaveAtom,
   submitKeyAtom,
 } from "@/lib/jotai/settings-atoms";
 import { resetSetting } from "@/lib/settings/reset-settings";
-import { DEFAULT_SETTINGS, type SubmitKeyOption } from "@/lib/settings/types";
+import {
+  DEFAULT_SETTINGS,
+  type InputStyleOption,
+  type SubmitKeyOption,
+} from "@/lib/settings/types";
 
 export default function EditorSection() {
   const [markdownHighlighting, setMarkdownHighlighting] = useAtom(
     markdownHighlightingAtom,
   );
   const [submitKey, setSubmitKey] = useAtom(submitKeyAtom);
+  const [inputStyle, setInputStyle] = useAtom(inputStyleAtom);
   const [regenerateOnSave, setRegenerateOnSave] = useAtom(regenerateOnSaveAtom);
 
   const isMarkdownHighlightingDefault =
     markdownHighlighting === DEFAULT_SETTINGS.MARKDOWN_HIGHLIGHTING;
   const isSubmitKeyDefault = submitKey === DEFAULT_SETTINGS.SUBMIT_KEY;
+  const isInputStyleDefault = inputStyle === DEFAULT_SETTINGS.INPUT_STYLE;
   const isRegenerateOnSaveDefault =
     regenerateOnSave === DEFAULT_SETTINGS.REGENERATE_ON_SAVE;
 
@@ -43,6 +50,10 @@ export default function EditorSection() {
 
   const handleResetRegenerateOnSave = () => {
     resetSetting("REGENERATE_ON_SAVE");
+  };
+
+  const handleResetInputStyle = () => {
+    resetSetting("INPUT_STYLE");
   };
 
   return (
@@ -129,6 +140,41 @@ export default function EditorSection() {
               size="icon"
               onClick={handleResetSubmitKey}
               disabled={isSubmitKeyDefault}
+              aria-label="Reset to default"
+            >
+              <RotateCcwIcon className="size-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
+          <div className="flex flex-1 flex-col items-start">
+            <Label className="text-sm font-medium">Input Style</Label>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Choose how the chat input box is displayed. Docked attaches to the
+              bottom, floating adds spacing and rounded corners.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Select
+              value={inputStyle}
+              onValueChange={(value) =>
+                setInputStyle(value as InputStyleOption)
+              }
+            >
+              <SelectTrigger className="w-full md:w-fit md:max-w-96">
+                <SelectValue placeholder="Select style" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="docked">Docked</SelectItem>
+                <SelectItem value="floating">Floating</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleResetInputStyle}
+              disabled={isInputStyleDefault}
               aria-label="Reset to default"
             >
               <RotateCcwIcon className="size-4" />


### PR DESCRIPTION
Adds an option to make the main chat input a floating input like Claude's for example v.s. the docked one (similar to t3.chat when it first launched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Input Style setting to customize chat input appearance with docked or floating mode options
  * Added reset control in settings to restore default input style

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->