### PR TITLE
mcp improvments

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -59,7 +59,7 @@
     "os:default",
     {
       "identifier": "http:default",
-      "allow": [{ "url": "https://opencode.ai/**" }]
+      "allow": [{ "url": "https://**" }, { "url": "http://**" }]
     }
   ]
 }

--- a/src/contexts/use-tools/tools-context.tsx
+++ b/src/contexts/use-tools/tools-context.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/lib/ai/tools";
 import {
   closeServerCache,
-  getCacheVersion,
   getMcpToolsForServer,
   invalidateServerCache,
 } from "@/lib/ai/tools/mcp";
@@ -75,9 +74,8 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
   const mcpToolsRef = useRef<ToolSet>({});
   const mcpLoadedRef = useRef(false);
   const loadingPromiseRef = useRef<Promise<void> | null>(null);
-  const previousEnabledServerIdsRef = useRef<Set<string>>(new Set());
-  const previousServersHashRef = useRef<string>("");
-  const currentVersionRef = useRef(0);
+  const enabledServerIdsRef = useRef<Set<string>>(new Set());
+  const loadIdRef = useRef(0);
 
   useEffect(() => {
     mcpToolsRef.current = mcpTools;
@@ -89,34 +87,14 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
       ? mcpServers.filter((server) => server.enabled)
       : [];
 
-    const serversHash = JSON.stringify(
-      enabledServers.map((s) => ({
-        id: s.id,
-        command: s.command,
-        timeout: s.timeoutMs,
-        requiresApproval: s.requiresApproval,
-      })),
-    );
-
-    if (serversHash === previousServersHashRef.current) {
-      return;
-    }
-
-    previousServersHashRef.current = serversHash;
-
-    const newEnabledServerIds = new Set(enabledServers.map((s) => s.id));
-    const previousEnabledServerIds = previousEnabledServerIdsRef.current;
-
-    for (const serverId of previousEnabledServerIds) {
-      if (!newEnabledServerIds.has(serverId)) {
+    const newEnabledIds = new Set(enabledServers.map((server) => server.id));
+    for (const serverId of enabledServerIdsRef.current) {
+      if (!newEnabledIds.has(serverId)) {
         logger.verbose(`Cleaning up disabled server: ${serverId}`);
         closeServerCache(serverId);
       }
     }
-
-    previousEnabledServerIdsRef.current = newEnabledServerIds;
-    const version = getCacheVersion();
-    currentVersionRef.current = version;
+    enabledServerIdsRef.current = newEnabledIds;
 
     if (enabledServers.length === 0) {
       invalidateServerCache();
@@ -128,15 +106,15 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
       return;
     }
 
-    const loadMcpTools = async () => {
-      if (currentVersionRef.current !== version) return;
+    const loadId = ++loadIdRef.current;
 
+    const loadMcpTools = async () => {
       mcpLoadedRef.current = false;
       setIsMcpLoading(true);
       setMcpLoaded(false);
 
       try {
-        const chunks = [];
+        const chunks: McpServerConfig[][] = [];
         for (let i = 0; i < enabledServers.length; i += parallelLoadLimit) {
           chunks.push(enabledServers.slice(i, i + parallelLoadLimit));
         }
@@ -144,42 +122,45 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
         const allTools: ToolSet = {};
 
         for (const chunk of chunks) {
-          if (currentVersionRef.current !== version) return;
+          if (loadId !== loadIdRef.current) return;
 
-          const promises = chunk.map(async (server: McpServerConfig) => {
-            try {
-              const tools = await Promise.race([
-                getMcpToolsForServer(server),
-                new Promise<ToolSet>((_, reject) =>
-                  setTimeout(
-                    () =>
-                      reject(new Error(`Timeout after ${server.timeoutMs}ms`)),
-                    server.timeoutMs,
+          const results = await Promise.all(
+            chunk.map(async (server) => {
+              try {
+                const tools = await Promise.race([
+                  getMcpToolsForServer(server),
+                  new Promise<ToolSet>((_, reject) =>
+                    setTimeout(
+                      () =>
+                        reject(
+                          new Error(`Timeout after ${server.timeoutMs}ms`),
+                        ),
+                      server.timeoutMs,
+                    ),
                   ),
-                ),
-              ]);
-              const wrappedTools = applyNeedsApprovalToTools(
-                tools,
-                server.requiresApproval ?? false,
-              );
-              return { serverId: server.id, tools: wrappedTools };
-            } catch (error) {
-              logger.error(
-                `Failed to load MCP tools for server ${server.name}:`,
-                error,
-              );
-              closeServerCache(server.id);
-              return { serverId: server.id, tools: {} };
-            }
-          });
+                ]);
+                const wrappedTools = applyNeedsApprovalToTools(
+                  tools,
+                  server.requiresApproval ?? false,
+                );
+                return { serverId: server.id, tools: wrappedTools };
+              } catch (error) {
+                logger.error(
+                  `Failed to load MCP tools for server ${server.name}:`,
+                  error,
+                );
+                closeServerCache(server.id);
+                return { serverId: server.id, tools: {} };
+              }
+            }),
+          );
 
-          const results = await Promise.all(promises);
           for (const result of results) {
             Object.assign(allTools, result.tools);
           }
         }
 
-        if (currentVersionRef.current !== version) return;
+        if (loadId !== loadIdRef.current) return;
 
         mcpToolsRef.current = allTools;
         mcpLoadedRef.current = true;

--- a/src/contexts/use-tools/tools-context.tsx
+++ b/src/contexts/use-tools/tools-context.tsx
@@ -42,7 +42,6 @@ interface ToolsProviderProps {
   children: ReactNode;
 }
 
-// TODO: Later, allow setting approval requirements on a per-tool basis for MCP servers, rather than for all tools in that server?
 function applyNeedsApprovalToTools(
   tools: ToolSet,
   needsApproval: boolean,
@@ -145,8 +144,10 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
                 );
                 return { serverId: server.id, tools: wrappedTools };
               } catch (error) {
+                const serverTypeLabel =
+                  server.type === "stdio" ? "STDIO" : "HTTP";
                 logger.error(
-                  `Failed to load MCP tools for server ${server.name}:`,
+                  `Failed to load MCP tools for ${serverTypeLabel} server ${server.name}:`,
                   error,
                 );
                 closeServerCache(server.id);

--- a/src/lib/ai/tools/mcp.ts
+++ b/src/lib/ai/tools/mcp.ts
@@ -16,6 +16,7 @@ interface ManagedMCPServer {
   client: MCPClient;
   transport: TauriStdioMCPTransport;
   tools: ToolSet;
+  configHash: string;
 }
 
 interface LoadingOperation {
@@ -25,7 +26,6 @@ interface LoadingOperation {
 
 const serverCache = new Map<string, ManagedMCPServer>();
 const loadingOperations = new Map<string, LoadingOperation>();
-let cacheVersion = 0;
 
 class TauriStdioMCPTransport implements MCPTransport {
   public onclose?: () => void;
@@ -117,6 +117,10 @@ class TauriStdioMCPTransport implements MCPTransport {
   }
 }
 
+function getConfigHash(server: McpServerConfig): string {
+  return JSON.stringify({ command: server.command });
+}
+
 async function getMcpClientAndTools(
   server: McpServerConfig,
   signal: AbortSignal,
@@ -170,25 +174,37 @@ async function getMcpClientAndTools(
 export async function getMcpToolsForServer(
   server: McpServerConfig,
 ): Promise<ToolSet> {
-  try {
-    const cached = serverCache.get(server.id);
-    if (cached) {
-      return cached.tools;
+  const configHash = getConfigHash(server);
+  const cached = serverCache.get(server.id);
+
+  if (cached && cached.configHash === configHash) {
+    return cached.tools;
+  }
+
+  if (cached && cached.configHash !== configHash) {
+    closeServerCache(server.id);
+  }
+
+  const existingLoad = loadingOperations.get(server.id);
+  if (existingLoad) {
+    await existingLoad.promise;
+    return serverCache.get(server.id)?.tools || {};
+  }
+
+  const controller = new AbortController();
+
+  const promise = (async () => {
+    try {
+      const result = await getMcpClientAndTools(server, controller.signal);
+      serverCache.set(server.id, { ...result, configHash });
+    } finally {
+      loadingOperations.delete(server.id);
     }
+  })();
 
-    const controller = new AbortController();
+  loadingOperations.set(server.id, { controller, promise });
 
-    const promise = (async () => {
-      try {
-        const result = await getMcpClientAndTools(server, controller.signal);
-        serverCache.set(server.id, result);
-      } finally {
-        loadingOperations.delete(server.id);
-      }
-    })();
-
-    loadingOperations.set(server.id, { controller, promise });
-
+  try {
     await promise;
     return serverCache.get(server.id)?.tools || {};
   } catch (error) {
@@ -214,7 +230,6 @@ export function closeServerCache(serverId: string): void {
 }
 
 export function invalidateServerCache(): void {
-  cacheVersion++;
   for (const [, loading] of loadingOperations) {
     loading.controller.abort();
   }
@@ -225,8 +240,4 @@ export function invalidateServerCache(): void {
     });
   }
   serverCache.clear();
-}
-
-export function getCacheVersion(): number {
-  return cacheVersion;
 }

--- a/src/lib/ai/tools/mcp.ts
+++ b/src/lib/ai/tools/mcp.ts
@@ -4,17 +4,22 @@ import {
   type JSONRPCMessage,
   type MCPTransport,
 } from "@ai-sdk/mcp";
+import { fetch } from "@tauri-apps/plugin-http";
 import { type Child, Command } from "@tauri-apps/plugin-shell";
 import type { ToolSet } from "ai";
 
 import { getLogger } from "@/lib/logger";
-import { type McpServerConfig } from "@/lib/settings/types";
+import {
+  type McpHttpServerConfig,
+  type McpServerConfig,
+  type McpStdioServerConfig,
+} from "@/lib/settings/types";
 
 const logger = getLogger(import.meta.url);
 
 interface ManagedMCPServer {
   client: MCPClient;
-  transport: TauriStdioMCPTransport;
+  transport: MCPTransport;
   tools: ToolSet;
   configHash: string;
 }
@@ -117,8 +122,193 @@ class TauriStdioMCPTransport implements MCPTransport {
   }
 }
 
+class TauriHttpMCPTransport implements MCPTransport {
+  public onclose?: () => void;
+  public onerror?: (error: Error) => void;
+  public onmessage?: (message: JSONRPCMessage) => void;
+
+  private url: string;
+  private headers: Record<string, string>;
+  private sessionId?: string;
+  private closed = false;
+
+  constructor(url: string, headers?: Record<string, string>) {
+    this.url = url;
+    this.headers = headers || {};
+  }
+
+  async start(): Promise<void> {
+    this.closed = false;
+    logger.verbose(`[MCP HTTP] Starting transport for ${this.url}`);
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (this.closed) {
+      throw new Error("Transport is closed");
+    }
+
+    try {
+      const requestHeaders: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        ...this.headers,
+      };
+
+      if (this.sessionId) {
+        requestHeaders["mcp-session-id"] = this.sessionId;
+      }
+
+      logger.verbose(`[MCP HTTP] Sending message:`, message);
+
+      const response = await fetch(this.url, {
+        method: "POST",
+        headers: requestHeaders,
+        body: JSON.stringify(message),
+      });
+
+      const newSessionId = response.headers.get("mcp-session-id");
+      if (newSessionId) {
+        this.sessionId = newSessionId;
+        logger.verbose(`[MCP HTTP] Session ID set to: ${this.sessionId}`);
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `HTTP error ${response.status}: ${response.statusText} - ${errorText}`,
+        );
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+
+      if (contentType.includes("text/event-stream")) {
+        await this.handleStreamResponse(response);
+      } else if (contentType.includes("application/json")) {
+        const responseText = await response.text();
+        if (responseText.trim()) {
+          const responseMessage = JSON.parse(responseText) as JSONRPCMessage;
+          logger.verbose(`[MCP HTTP] Received response:`, responseMessage);
+          this.onmessage?.(responseMessage);
+        }
+      } else {
+        const responseText = await response.text();
+        if (responseText.trim()) {
+          try {
+            const responseMessage = JSON.parse(responseText) as JSONRPCMessage;
+            logger.verbose(`[MCP HTTP] Received response:`, responseMessage);
+            this.onmessage?.(responseMessage);
+          } catch {
+            logger.warn(
+              `[MCP HTTP] Could not parse response as JSON:`,
+              responseText,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      logger.error(`[MCP HTTP] Error sending message:`, error);
+      this.onerror?.(error as Error);
+      throw error;
+    }
+  }
+
+  private async handleStreamResponse(response: Response): Promise<void> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("No response body reader available");
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            const data = line.slice(6).trim();
+            if (data && data !== "[DONE]") {
+              try {
+                const message = JSON.parse(data) as JSONRPCMessage;
+                logger.verbose(`[MCP HTTP] Received stream message:`, message);
+                this.onmessage?.(message);
+              } catch {
+                logger.warn(`[MCP HTTP] Failed to parse stream data:`, data);
+              }
+            }
+          } else if (line.trim() && !line.startsWith(":")) {
+            try {
+              const message = JSON.parse(line) as JSONRPCMessage;
+              logger.verbose(`[MCP HTTP] Received JSONL message:`, message);
+              this.onmessage?.(message);
+            } catch {
+              // Not JSON, might be a comment or other format
+            }
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        try {
+          const message = JSON.parse(buffer) as JSONRPCMessage;
+          logger.verbose(`[MCP HTTP] Received final message:`, message);
+          this.onmessage?.(message);
+        } catch {
+          // Ignore unparseable final buffer
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+
+    if (this.sessionId) {
+      try {
+        await fetch(this.url, {
+          method: "DELETE",
+          headers: {
+            "mcp-session-id": this.sessionId,
+            ...this.headers,
+          },
+        });
+        logger.verbose(`[MCP HTTP] Session closed: ${this.sessionId}`);
+      } catch (error) {
+        logger.verbose(`[MCP HTTP] Error closing session:`, error);
+      }
+    }
+
+    this.onclose?.();
+  }
+}
+
 function getConfigHash(server: McpServerConfig): string {
-  return JSON.stringify({ command: server.command });
+  if (server.type === "stdio") {
+    return JSON.stringify({ type: "stdio", command: server.command });
+  } else {
+    return JSON.stringify({
+      type: "http",
+      url: server.url,
+      headers: server.headers,
+    });
+  }
+}
+
+function createTransport(server: McpServerConfig): MCPTransport {
+  if (server.type === "stdio") {
+    return new TauriStdioMCPTransport(server.command);
+  } else {
+    return new TauriHttpMCPTransport(server.url, server.headers);
+  }
 }
 
 async function getMcpClientAndTools(
@@ -127,13 +317,13 @@ async function getMcpClientAndTools(
 ): Promise<{
   client: MCPClient;
   tools: ToolSet;
-  transport: TauriStdioMCPTransport;
+  transport: MCPTransport;
 }> {
   if (signal.aborted) {
     throw new Error("Operation aborted");
   }
 
-  const transport = new TauriStdioMCPTransport(server.command);
+  const transport = createTransport(server);
 
   const onAbort = () => {
     transport.close().catch((error) => {
@@ -158,8 +348,9 @@ async function getMcpClientAndTools(
       throw new Error("Operation aborted");
     }
 
+    const serverTypeLabel = server.type === "stdio" ? "STDIO" : "HTTP";
     logger.verbose(
-      `Successfully fetched MCP tools for ${server.name}:`,
+      `Successfully fetched MCP tools for ${server.name} (${serverTypeLabel}):`,
       Object.keys(tools),
     );
 

--- a/src/lib/ai/tools/mcp.ts
+++ b/src/lib/ai/tools/mcp.ts
@@ -9,11 +9,7 @@ import { type Child, Command } from "@tauri-apps/plugin-shell";
 import type { ToolSet } from "ai";
 
 import { getLogger } from "@/lib/logger";
-import {
-  type McpHttpServerConfig,
-  type McpServerConfig,
-  type McpStdioServerConfig,
-} from "@/lib/settings/types";
+import { type McpServerConfig } from "@/lib/settings/types";
 
 const logger = getLogger(import.meta.url);
 
@@ -261,7 +257,7 @@ class TauriHttpMCPTransport implements MCPTransport {
           logger.verbose(`[MCP HTTP] Received final message:`, message);
           this.onmessage?.(message);
         } catch {
-          // Ignore unparseable final buffer
+          // Ignore final buffer that cannot be parsed
         }
       }
     } finally {

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -33,14 +33,28 @@ export interface TitleGenerationSettings {
   fallbackPhrase: string;
 }
 
-export interface McpServerConfig {
+export type McpServerType = "stdio" | "http";
+
+export interface McpServerConfigBase {
   id: string;
   name: string;
-  command: string;
   enabled: boolean;
   timeoutMs: number;
   requiresApproval: boolean;
 }
+
+export interface McpStdioServerConfig extends McpServerConfigBase {
+  type: "stdio";
+  command: string;
+}
+
+export interface McpHttpServerConfig extends McpServerConfigBase {
+  type: "http";
+  url: string;
+  headers: Record<string, string>;
+}
+
+export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;
 
 export type ToolId =
   | "dateTime"
@@ -175,6 +189,7 @@ export const DEFAULT_SETTINGS: DefaultSettings = {
     {
       id: "everything",
       name: "Everything Server",
+      type: "stdio",
       command: "npx -y @modelcontextprotocol/server-everything",
       enabled: true,
       timeoutMs: 30000,

--- a/src/routes/settings/sections/mcp.tsx
+++ b/src/routes/settings/sections/mcp.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from "jotai";
-import { RotateCcwIcon, Trash2Icon } from "lucide-react";
+import { PlusIcon, RotateCcwIcon, Trash2Icon } from "lucide-react";
 import { useState } from "react";
 
 import { NoMcpServers } from "@/components/a1/empty-states/no-mcp-servers";
@@ -21,13 +21,31 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
   mcpParallelLoadLimitAtom,
   mcpServersAtom,
 } from "@/lib/jotai/settings-atoms";
 import { resetSetting } from "@/lib/settings/reset-settings";
-import { DEFAULT_SETTINGS, type McpServerConfig } from "@/lib/settings/types";
+import {
+  DEFAULT_SETTINGS,
+  type McpHttpServerConfig,
+  type McpServerConfig,
+  type McpServerType,
+  type McpStdioServerConfig,
+} from "@/lib/settings/types";
+
+interface HeaderEntry {
+  key: string;
+  value: string;
+}
 
 export default function McpSection() {
   const [mcpServers, setMcpServers] = useAtom(mcpServersAtom);
@@ -48,7 +66,7 @@ export default function McpSection() {
   ) => {
     setMcpServers((prev) =>
       prev.map((server, i) =>
-        i === index ? { ...server, ...updates } : server,
+        i === index ? ({ ...server, ...updates } as McpServerConfig) : server,
       ),
     );
   };
@@ -56,42 +74,73 @@ export default function McpSection() {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [serverToDelete, setServerToDelete] = useState<number | null>(null);
+
+  const [newServerType, setNewServerType] = useState<McpServerType>("stdio");
   const [newServerName, setNewServerName] = useState("");
   const [newServerCommand, setNewServerCommand] = useState("");
+  const [newServerUrl, setNewServerUrl] = useState("");
+  const [newServerHeaders, setNewServerHeaders] = useState<HeaderEntry[]>([]);
   const [newServerTimeoutSec, setNewServerTimeoutSec] = useState(30);
   const [newServerRequiresApproval, setNewServerRequiresApproval] =
     useState(false);
 
   const isAddFormValid =
     newServerName.trim() !== "" &&
-    newServerCommand.trim() !== "" &&
-    newServerTimeoutSec >= 0.1;
+    newServerTimeoutSec >= 0.1 &&
+    (newServerType === "stdio"
+      ? newServerCommand.trim() !== ""
+      : newServerUrl.trim() !== "");
 
   const handleAddServer = () => {
     if (!isAddFormValid) return;
 
-    const newServer: McpServerConfig = {
+    const baseConfig = {
       id: `server-${Date.now()}`,
       name: newServerName.trim(),
-      command: newServerCommand.trim(),
       enabled: true,
       timeoutMs: newServerTimeoutSec * 1000,
       requiresApproval: newServerRequiresApproval,
     };
-    setMcpServers((prev) => [newServer, ...prev]);
 
-    setNewServerName("");
-    setNewServerCommand("");
-    setNewServerTimeoutSec(30);
-    setNewServerRequiresApproval(false);
+    let newServer: McpServerConfig;
+    if (newServerType === "stdio") {
+      newServer = {
+        ...baseConfig,
+        type: "stdio",
+        command: newServerCommand.trim(),
+      };
+    } else {
+      const headers: Record<string, string> = {};
+      for (const entry of newServerHeaders) {
+        if (entry.key.trim() && entry.value.trim()) {
+          headers[entry.key.trim()] = entry.value.trim();
+        }
+      }
+      newServer = {
+        ...baseConfig,
+        type: "http",
+        url: newServerUrl.trim(),
+        headers,
+      };
+    }
+
+    setMcpServers((prev) => [newServer, ...prev]);
+    resetAddForm();
     setShowAddDialog(false);
   };
 
-  const handleCancelAdd = () => {
+  const resetAddForm = () => {
+    setNewServerType("stdio");
     setNewServerName("");
     setNewServerCommand("");
+    setNewServerUrl("");
+    setNewServerHeaders([]);
     setNewServerTimeoutSec(30);
     setNewServerRequiresApproval(false);
+  };
+
+  const handleCancelAdd = () => {
+    resetAddForm();
     setShowAddDialog(false);
   };
 
@@ -111,6 +160,30 @@ export default function McpSection() {
   const cancelDelete = () => {
     setServerToDelete(null);
     setShowDeleteDialog(false);
+  };
+
+  const addHeaderEntry = () => {
+    setNewServerHeaders((prev) => [...prev, { key: "", value: "" }]);
+  };
+
+  const updateHeaderEntry = (
+    index: number,
+    field: "key" | "value",
+    value: string,
+  ) => {
+    setNewServerHeaders((prev) =>
+      prev.map((entry, i) =>
+        i === index ? { ...entry, [field]: value } : entry,
+      ),
+    );
+  };
+
+  const removeHeaderEntry = (index: number) => {
+    setNewServerHeaders((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const getServerTypeLabel = (server: McpServerConfig) => {
+    return server.type === "stdio" ? "STDIO" : "HTTP";
   };
 
   return (
@@ -168,7 +241,12 @@ export default function McpSection() {
               <AccordionItem key={server.id} value={server.id}>
                 <AccordionTrigger className="px-3 hover:no-underline">
                   <div className="flex flex-1 items-center justify-between">
-                    <span>{server.name || "Unnamed Server"}</span>
+                    <div className="flex items-center gap-2">
+                      <span>{server.name || "Unnamed Server"}</span>
+                      <span className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-xs">
+                        {getServerTypeLabel(server)}
+                      </span>
+                    </div>
                     <Switch
                       id={`enabled-${server.id}`}
                       checked={server.enabled}
@@ -223,22 +301,50 @@ export default function McpSection() {
                       </div>
                     </div>
 
-                    <div className="grid gap-1.5">
-                      <Label
-                        htmlFor={`command-${server.id}`}
-                        className="text-xs"
-                      >
-                        Command
-                      </Label>
-                      <Input
-                        id={`command-${server.id}`}
-                        value={server.command}
-                        onChange={(e) =>
-                          updateMcpServer(index, { command: e.target.value })
-                        }
-                        placeholder="e.g., npx -y @modelcontextprotocol/server-everything"
-                      />
-                    </div>
+                    {server.type === "stdio" ? (
+                      <div className="grid gap-1.5">
+                        <Label
+                          htmlFor={`command-${server.id}`}
+                          className="text-xs"
+                        >
+                          Command
+                        </Label>
+                        <Input
+                          id={`command-${server.id}`}
+                          value={server.command}
+                          onChange={(e) =>
+                            updateMcpServer(index, { command: e.target.value })
+                          }
+                          placeholder="e.g., npx -y @modelcontextprotocol/server-everything"
+                        />
+                      </div>
+                    ) : (
+                      <>
+                        <div className="grid gap-1.5">
+                          <Label
+                            htmlFor={`url-${server.id}`}
+                            className="text-xs"
+                          >
+                            URL
+                          </Label>
+                          <Input
+                            id={`url-${server.id}`}
+                            value={server.url}
+                            onChange={(e) =>
+                              updateMcpServer(index, { url: e.target.value })
+                            }
+                            placeholder="https://mcp.example.com/api"
+                          />
+                        </div>
+                        <HttpHeadersEditor
+                          serverId={server.id}
+                          headers={server.headers}
+                          onChange={(headers) =>
+                            updateMcpServer(index, { headers })
+                          }
+                        />
+                      </>
+                    )}
 
                     <div className="flex items-center justify-between">
                       <div className="flex flex-col">
@@ -282,7 +388,7 @@ export default function McpSection() {
       </CardContent>
 
       <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
-        <DialogContent>
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Add MCP Server</DialogTitle>
             <DialogDescription>
@@ -291,6 +397,29 @@ export default function McpSection() {
           </DialogHeader>
 
           <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="server-type">Server Type</Label>
+              <Select
+                value={newServerType}
+                onValueChange={(value: McpServerType) =>
+                  setNewServerType(value)
+                }
+              >
+                <SelectTrigger id="server-type">
+                  <SelectValue placeholder="Select server type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="stdio">STDIO (Local)</SelectItem>
+                  <SelectItem value="http">HTTP (Remote)</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-muted-foreground text-xs">
+                {newServerType === "stdio"
+                  ? "STDIO servers run locally via command line."
+                  : "HTTP servers are remote endpoints that support the MCP protocol."}
+              </p>
+            </div>
+
             <div className="grid gap-2">
               <Label htmlFor="server-name">Name</Label>
               <Input
@@ -301,15 +430,81 @@ export default function McpSection() {
               />
             </div>
 
-            <div className="grid gap-2">
-              <Label htmlFor="server-command">Command</Label>
-              <Input
-                id="server-command"
-                placeholder="e.g., npx -y @modelcontextprotocol/server-everything"
-                value={newServerCommand}
-                onChange={(e) => setNewServerCommand(e.target.value)}
-              />
-            </div>
+            {newServerType === "stdio" ? (
+              <div className="grid gap-2">
+                <Label htmlFor="server-command">Command</Label>
+                <Input
+                  id="server-command"
+                  placeholder="e.g., npx -y @modelcontextprotocol/server-everything"
+                  value={newServerCommand}
+                  onChange={(e) => setNewServerCommand(e.target.value)}
+                />
+              </div>
+            ) : (
+              <>
+                <div className="grid gap-2">
+                  <Label htmlFor="server-url">URL</Label>
+                  <Input
+                    id="server-url"
+                    placeholder="https://mcp.example.com/api"
+                    value={newServerUrl}
+                    onChange={(e) => setNewServerUrl(e.target.value)}
+                  />
+                </div>
+
+                <div className="grid gap-2">
+                  <div className="flex items-center justify-between">
+                    <Label>HTTP Headers</Label>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={addHeaderEntry}
+                    >
+                      <PlusIcon className="size-4" />
+                      Add Header
+                    </Button>
+                  </div>
+                  {newServerHeaders.length > 0 ? (
+                    <div className="flex flex-col gap-2">
+                      {newServerHeaders.map((entry, idx) => (
+                        <div key={idx} className="flex items-center gap-2">
+                          <Input
+                            placeholder="Header name"
+                            value={entry.key}
+                            onChange={(e) =>
+                              updateHeaderEntry(idx, "key", e.target.value)
+                            }
+                            className="flex-1"
+                          />
+                          <Input
+                            placeholder="Value"
+                            value={entry.value}
+                            onChange={(e) =>
+                              updateHeaderEntry(idx, "value", e.target.value)
+                            }
+                            className="flex-1"
+                          />
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => removeHeaderEntry(idx)}
+                          >
+                            <Trash2Icon className="size-4" />
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-muted-foreground text-sm">
+                      No headers configured. Add headers for authentication or
+                      other purposes.
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
 
             <div className="grid gap-2">
               <Label htmlFor="server-timeout">Timeout (seconds)</Label>
@@ -375,5 +570,90 @@ export default function McpSection() {
         </DialogContent>
       </Dialog>
     </Card>
+  );
+}
+
+function HttpHeadersEditor({
+  serverId,
+  headers,
+  onChange,
+}: {
+  serverId: string;
+  headers: Record<string, string>;
+  onChange: (headers: Record<string, string>) => void;
+}) {
+  const entries = Object.entries(headers);
+
+  const addHeader = () => {
+    onChange({ ...headers, "": "" });
+  };
+
+  const updateHeader = (
+    oldKey: string,
+    newKey: string,
+    newValue: string,
+    index: number,
+  ) => {
+    const newHeaders: Record<string, string> = {};
+    let i = 0;
+    for (const [key, value] of Object.entries(headers)) {
+      if (i === index) {
+        if (newKey.trim()) {
+          newHeaders[newKey] = newValue;
+        }
+      } else {
+        newHeaders[key] = value;
+      }
+      i++;
+    }
+    onChange(newHeaders);
+  };
+
+  const removeHeader = (keyToRemove: string) => {
+    const newHeaders = { ...headers };
+    delete newHeaders[keyToRemove];
+    onChange(newHeaders);
+  };
+
+  return (
+    <div className="grid gap-1.5">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">HTTP Headers</Label>
+        <Button type="button" variant="outline" size="sm" onClick={addHeader}>
+          <PlusIcon className="size-4" />
+          Add
+        </Button>
+      </div>
+      {entries.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {entries.map(([key, value], idx) => (
+            <div key={`${serverId}-header-${idx}`} className="flex gap-2">
+              <Input
+                placeholder="Header name"
+                value={key}
+                onChange={(e) => updateHeader(key, e.target.value, value, idx)}
+                className="flex-1"
+              />
+              <Input
+                placeholder="Value"
+                value={value}
+                onChange={(e) => updateHeader(key, key, e.target.value, idx)}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeHeader(key)}
+              >
+                <Trash2Icon className="size-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-xs">No headers configured.</p>
+      )}
+    </div>
   );
 }

--- a/src/routes/settings/sections/mcp.tsx
+++ b/src/routes/settings/sections/mcp.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import { PlusIcon, RotateCcwIcon, Trash2Icon } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 import { NoMcpServers } from "@/components/a1/empty-states/no-mcp-servers";
 import {
@@ -36,10 +36,8 @@ import {
 import { resetSetting } from "@/lib/settings/reset-settings";
 import {
   DEFAULT_SETTINGS,
-  type McpHttpServerConfig,
   type McpServerConfig,
   type McpServerType,
-  type McpStdioServerConfig,
 } from "@/lib/settings/types";
 
 interface HeaderEntry {
@@ -52,6 +50,8 @@ export default function McpSection() {
   const [parallelLoadLimit, setParallelLoadLimit] = useAtom(
     mcpParallelLoadLimitAtom,
   );
+
+  const uniqueId = useId();
 
   const isParallelLoadLimitDefault =
     parallelLoadLimit === DEFAULT_SETTINGS.MCP_PARALLEL_LOAD_LIMIT;
@@ -95,7 +95,7 @@ export default function McpSection() {
     if (!isAddFormValid) return;
 
     const baseConfig = {
-      id: `server-${Date.now()}`,
+      id: `server-${uniqueId}-${crypto.randomUUID()}`,
       name: newServerName.trim(),
       enabled: true,
       timeoutMs: newServerTimeoutSec * 1000,
@@ -588,12 +588,7 @@ function HttpHeadersEditor({
     onChange({ ...headers, "": "" });
   };
 
-  const updateHeader = (
-    oldKey: string,
-    newKey: string,
-    newValue: string,
-    index: number,
-  ) => {
+  const updateHeader = (newKey: string, newValue: string, index: number) => {
     const newHeaders: Record<string, string> = {};
     let i = 0;
     for (const [key, value] of Object.entries(headers)) {
@@ -631,13 +626,13 @@ function HttpHeadersEditor({
               <Input
                 placeholder="Header name"
                 value={key}
-                onChange={(e) => updateHeader(key, e.target.value, value, idx)}
+                onChange={(e) => updateHeader(e.target.value, value, idx)}
                 className="flex-1"
               />
               <Input
                 placeholder="Value"
                 value={value}
-                onChange={(e) => updateHeader(key, key, e.target.value, idx)}
+                onChange={(e) => updateHeader(key, e.target.value, idx)}
                 className="flex-1"
               />
               <Button


### PR DESCRIPTION
#86 

- [x] Ensure modifying one MCP server doesn't reload all of them.
- [x] Support common MCP server types (HTTP and STDIO), but DO NOT support SSE.
- [ ] FULLY support OAuth for MCP servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP-based MCP server support alongside existing STDIO servers
  * Users can select server type (STDIO or HTTP) when configuring MCP servers
  * Added HTTP headers editor for HTTP-based server configuration
  * Broadened network access permissions to support all HTTP/HTTPS URLs

* **Improvements**
  * Enhanced MCP server loading with better error handling and timeout management
  * Improved cache invalidation and prevents stale request processing
  * Server type badges now display in the MCP server list

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->