### PR TITLE
fix mcp and status=submitted hanging when trying to cancel response

### DIFF
--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -95,6 +95,7 @@ export const MultiChatProvider = ({ children }: { children: ReactNode }) => {
     new Set(),
   );
   const loadVersionRef = useRef(0);
+  const autoSubmitBlockedRef = useRef<Set<string>>(new Set());
 
   const isChatLoading = useMemo(() => {
     if (!currentChatId) return false;
@@ -425,6 +426,67 @@ export const MultiChatProvider = ({ children }: { children: ReactNode }) => {
     sendMessage,
   } = instanceForFunctions;
 
+  const clearAutoSubmitBlockForCurrentChat = useCallback(() => {
+    if (!currentChatId) {
+      return;
+    }
+    autoSubmitBlockedRef.current.delete(currentChatId);
+  }, [currentChatId]);
+
+  const stopWithAutoSubmitBlock = useCallback(() => {
+    if (currentChatId) {
+      autoSubmitBlockedRef.current.add(currentChatId);
+    }
+    return stop();
+  }, [currentChatId, stop]);
+
+  const sendMessageWithAutoSubmitReset = useCallback(
+    (
+      message: Parameters<typeof sendMessage>[0],
+      options?: Parameters<typeof sendMessage>[1],
+    ) => {
+      clearAutoSubmitBlockForCurrentChat();
+      return sendMessage(message, options);
+    },
+    [clearAutoSubmitBlockForCurrentChat, sendMessage],
+  );
+
+  const regenerateWithAutoSubmitReset = useCallback(
+    (options?: Parameters<typeof regenerate>[0]) => {
+      clearAutoSubmitBlockForCurrentChat();
+      return regenerate(options);
+    },
+    [clearAutoSubmitBlockForCurrentChat, regenerate],
+  );
+
+  const resumeStreamWithAutoSubmitReset = useCallback(
+    (...args: Parameters<typeof resumeStream>) => {
+      clearAutoSubmitBlockForCurrentChat();
+      return resumeStream(...args);
+    },
+    [clearAutoSubmitBlockForCurrentChat, resumeStream],
+  );
+
+  const addToolOutputWithAutoSubmitReset = useCallback(
+    (...args: Parameters<typeof addToolOutput>) => {
+      clearAutoSubmitBlockForCurrentChat();
+      return addToolOutput(...args);
+    },
+    [addToolOutput, clearAutoSubmitBlockForCurrentChat],
+  );
+
+  const addToolApprovalResponseWithAutoSubmitReset = useCallback(
+    (...args: Parameters<typeof addToolApprovalResponse>) => {
+      clearAutoSubmitBlockForCurrentChat();
+      return addToolApprovalResponse(...args);
+    },
+    [addToolApprovalResponse, clearAutoSubmitBlockForCurrentChat],
+  );
+
+  const isAutoSubmitBlocked = useCallback((id: string) => {
+    return autoSubmitBlockedRef.current.has(id);
+  }, []);
+
   const wasStreamingRef = useRef(false);
   useEffect(() => {
     if (statusValue.status === "streaming") {
@@ -502,25 +564,27 @@ export const MultiChatProvider = ({ children }: { children: ReactNode }) => {
 
   const functionsValue = useMemo(
     () => ({
-      sendMessage: isNewChat ? handleNewChatSubmit : sendMessage,
-      addToolOutput,
-      addToolApprovalResponse,
-      regenerate,
+      sendMessage: isNewChat
+        ? handleNewChatSubmit
+        : sendMessageWithAutoSubmitReset,
+      addToolOutput: addToolOutputWithAutoSubmitReset,
+      addToolApprovalResponse: addToolApprovalResponseWithAutoSubmitReset,
+      regenerate: regenerateWithAutoSubmitReset,
       clearError,
-      resumeStream,
-      stop,
+      resumeStream: resumeStreamWithAutoSubmitReset,
+      stop: stopWithAutoSubmitBlock,
       setMessages,
     }),
     [
       isNewChat,
       handleNewChatSubmit,
-      sendMessage,
-      addToolOutput,
-      addToolApprovalResponse,
-      regenerate,
+      sendMessageWithAutoSubmitReset,
+      addToolOutputWithAutoSubmitReset,
+      addToolApprovalResponseWithAutoSubmitReset,
+      regenerateWithAutoSubmitReset,
       clearError,
-      resumeStream,
-      stop,
+      resumeStreamWithAutoSubmitReset,
+      stopWithAutoSubmitBlock,
       setMessages,
     ],
   );
@@ -540,6 +604,7 @@ export const MultiChatProvider = ({ children }: { children: ReactNode }) => {
             model={chatModel.model}
             modelConfig={chatConfig}
             initialMessages={initialMessages}
+            isAutoSubmitBlocked={isAutoSubmitBlocked}
             onInstanceUpdate={handleInstanceUpdate}
             onStatusChange={handleStatusChange}
           />

--- a/src/contexts/use-chat/chat-context.tsx
+++ b/src/contexts/use-chat/chat-context.tsx
@@ -546,6 +546,7 @@ export const MultiChatProvider = ({ children }: { children: ReactNode }) => {
 
     chatInstancesRef.current.forEach((instance, id) => {
       if (!chatIds.includes(id)) {
+        autoSubmitBlockedRef.current.delete(id);
         const { status, stop } = instance;
         if (status === "streaming" || status === "submitted") {
           logger.verbose(`Stopping stream for deleted chat: ${id}`);

--- a/src/contexts/use-chat/chat-instance.tsx
+++ b/src/contexts/use-chat/chat-instance.tsx
@@ -31,6 +31,7 @@ export const ChatInstance = memo(
     model,
     modelConfig,
     initialMessages,
+    isAutoSubmitBlocked,
     onInstanceUpdate,
     onStatusChange,
   }: {
@@ -38,6 +39,7 @@ export const ChatInstance = memo(
     model: LanguageModel;
     modelConfig: ModelConfig;
     initialMessages: UIMessage[];
+    isAutoSubmitBlocked: (id: string) => boolean;
     onInstanceUpdate: (id: string, instance: UseChatHelpers<UIMessage>) => void;
     onStatusChange: (
       id: string,
@@ -61,9 +63,15 @@ export const ChatInstance = memo(
       experimental_throttle: experimentalThrottleEnabled
         ? experimentalThrottleValue
         : undefined,
-      sendAutomaticallyWhen: (messages) =>
-        lastAssistantMessageIsCompleteWithToolCalls(messages) ||
-        lastAssistantMessageIsCompleteWithApprovalResponses(messages),
+      sendAutomaticallyWhen: ({ messages }) => {
+        if (isAutoSubmitBlocked(chatId)) {
+          return false;
+        }
+        return (
+          lastAssistantMessageIsCompleteWithToolCalls({ messages }) ||
+          lastAssistantMessageIsCompleteWithApprovalResponses({ messages })
+        );
+      },
       id: chatId,
       messages: initialMessages,
     });
@@ -137,6 +145,7 @@ export const ChatInstance = memo(
       prevProps.chatId === nextProps.chatId &&
       prevProps.model === nextProps.model &&
       prevProps.initialMessages === nextProps.initialMessages &&
+      prevProps.isAutoSubmitBlocked === nextProps.isAutoSubmitBlocked &&
       prevProps.onInstanceUpdate === nextProps.onInstanceUpdate &&
       prevProps.onStatusChange === nextProps.onStatusChange &&
       JSON.stringify(prevProps.modelConfig) ===

--- a/src/lib/ai/custom-chat-transport.ts
+++ b/src/lib/ai/custom-chat-transport.ts
@@ -21,6 +21,59 @@ import { getLogger } from "@/lib/logger";
 
 const logger = getLogger(import.meta.url);
 
+function createAbortError(): Error {
+  const error = new Error("The operation was aborted.");
+  error.name = "AbortError";
+  return error;
+}
+
+function withAbortAwareToolExecution(tools: ToolSet): ToolSet {
+  const wrapped: ToolSet = {};
+
+  for (const [name, tool] of Object.entries(tools)) {
+    const execute = (tool as { execute?: unknown }).execute;
+
+    if (typeof execute !== "function") {
+      wrapped[name] = tool;
+      continue;
+    }
+
+    const originalExecute = execute as (
+      input: unknown,
+      context: { abortSignal?: AbortSignal },
+    ) => Promise<unknown>;
+
+    wrapped[name] = {
+      ...tool,
+      execute: async (
+        input: unknown,
+        context: { abortSignal?: AbortSignal },
+      ) => {
+        const signal = context?.abortSignal;
+        const executePromise = originalExecute(input, context);
+
+        if (!signal) {
+          return executePromise;
+        }
+
+        if (signal.aborted) {
+          throw createAbortError();
+        }
+
+        const abortPromise = new Promise<never>((_, reject) => {
+          signal.addEventListener("abort", () => reject(createAbortError()), {
+            once: true,
+          });
+        });
+
+        return Promise.race([executePromise, abortPromise]);
+      },
+    } as ToolSet[string];
+  }
+
+  return wrapped;
+}
+
 export class CustomChatTransport implements ChatTransport<UIMessage> {
   private model: LanguageModel | null;
   private modelId: string | null;
@@ -98,7 +151,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     }
 
     await this.getApiKeysLoadedPromise();
-    const tools = await this.getTools();
+    const tools = withAbortAwareToolExecution(await this.getTools());
 
     const result = streamText({
       model: this.model,

--- a/src/lib/ai/custom-chat-transport.ts
+++ b/src/lib/ai/custom-chat-transport.ts
@@ -50,23 +50,31 @@ function withAbortAwareToolExecution(tools: ToolSet): ToolSet {
         context: { abortSignal?: AbortSignal },
       ) => {
         const signal = context?.abortSignal;
-        const executePromise = originalExecute(input, context);
-
         if (!signal) {
-          return executePromise;
+          return originalExecute(input, context);
         }
 
         if (signal.aborted) {
           throw createAbortError();
         }
 
+        const executePromise = originalExecute(input, context);
+
+        let abortHandler: (() => void) | undefined;
         const abortPromise = new Promise<never>((_, reject) => {
-          signal.addEventListener("abort", () => reject(createAbortError()), {
+          abortHandler = () => reject(createAbortError());
+          signal.addEventListener("abort", abortHandler, {
             once: true,
           });
         });
 
-        return Promise.race([executePromise, abortPromise]);
+        try {
+          return await Promise.race([executePromise, abortPromise]);
+        } finally {
+          if (abortHandler) {
+            signal.removeEventListener("abort", abortHandler);
+          }
+        }
       },
     } as ToolSet[string];
   }

--- a/src/lib/ai/custom-chat-transport.ts
+++ b/src/lib/ai/custom-chat-transport.ts
@@ -62,7 +62,10 @@ function withAbortAwareToolExecution(tools: ToolSet): ToolSet {
 
         let abortHandler: (() => void) | undefined;
         const abortPromise = new Promise<never>((_, reject) => {
-          abortHandler = () => reject(createAbortError());
+          abortHandler = () => {
+            void executePromise.catch(() => {});
+            reject(createAbortError());
+          };
           signal.addEventListener("abort", abortHandler, {
             once: true,
           });


### PR DESCRIPTION
See title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Per-chat auto-submit blocking added and exposed to chat instances; actions for existing chats now reset this state automatically.
  * Chat components receive a new prop to reflect per-chat block state and reduce unnecessary re-renders.
  * Tool execution is now abort-aware, improving cancel/abort responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->