### PR TITLE
WIP migrating MCP servers to "Extensions"

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -29,13 +29,5 @@
         }
       }
     }
-  },
-  "mcp": {
-    "agentation": {
-      "type": "local",
-      "command": ["npx", "-y", "agentation-mcp", "server"],
-      "enabled": true,
-      "environment": {}
-    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,6 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/ui": "^4.0.18",
-        "agentation": "^2.2.1",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "jsdom": "^28.1.0",
         "prettier": "^3.8.1",
@@ -5590,25 +5589,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agentation": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/agentation/-/agentation-2.2.1.tgz",
-      "integrity": "sha512-yV9P1DggI7M3SRaRwLwt+xqE5lXqg5l8xtqCr8KzEkbnH8Wa6eRATU97uKnD7cC8FrsJP62Mmw0Xf5Xi5KV50Q==",
-      "dev": true,
-      "license": "PolyForm-Shield-1.0.0",
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/ai": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/ui": "^4.0.18",
-    "agentation": "^2.2.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jsdom": "^28.1.0",
     "prettier": "^3.8.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,9 +26,7 @@ function AppLayout() {
 function App() {
   return (
     <BrowserRouter>
-      {process.env.NODE_ENV === "development" && (
-        <Agentation endpoint="http://localhost:4747" />
-      )}
+      {process.env.NODE_ENV === "development" && <Agentation />}
       <KbdRegistry />
       <DeepLinkHandler />
       <Toaster position="top-right" richColors closeButton />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { Agentation } from "agentation";
 import { BrowserRouter, Outlet, Route, Routes } from "react-router";
 import { Toaster } from "sonner";
 
@@ -26,7 +25,6 @@ function AppLayout() {
 function App() {
   return (
     <BrowserRouter>
-      {process.env.NODE_ENV === "development" && <Agentation />}
       <KbdRegistry />
       <DeepLinkHandler />
       <Toaster position="top-right" richColors closeButton />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,9 @@ function AppLayout() {
 function App() {
   return (
     <BrowserRouter>
-      {process.env.NODE_ENV === "development" && <Agentation />}
+      {process.env.NODE_ENV === "development" && (
+        <Agentation endpoint="http://localhost:4747" />
+      )}
       <KbdRegistry />
       <DeepLinkHandler />
       <Toaster position="top-right" richColors closeButton />

--- a/src/assets/mcp-registry/mcp-registry.ts
+++ b/src/assets/mcp-registry/mcp-registry.ts
@@ -1,1 +1,538 @@
-// TODO
+import mcpRegistryData from "./mcp-registry.json";
+import type { MCPRegistryEntry } from "./types";
+
+type InstallFieldKind = "env" | "header" | "variable";
+
+export interface RegistryInstallField {
+  id: string;
+  kind: InstallFieldKind;
+  key: string;
+  label: string;
+  description?: string;
+  required: boolean;
+  secret: boolean;
+  defaultValue: string;
+  placeholder?: string;
+  choices?: string[];
+}
+
+export interface McpRegistryInstallTemplate {
+  type: "stdio" | "http";
+  commandTemplate?: string;
+  urlTemplate?: string;
+  envDefaults: Record<string, string>;
+  headerDefaults: Record<string, string>;
+  fields: RegistryInstallField[];
+}
+
+export interface McpRegistryExtension {
+  id: string;
+  registryName: string;
+  displayName: string;
+  description: string;
+  version: string;
+  websiteUrl?: string;
+  iconUrl?: string;
+  officialStatus?: string;
+  updatedAt?: string;
+  install?: McpRegistryInstallTemplate;
+  searchText: string;
+}
+
+export interface RegistryInstallSubmission {
+  name: string;
+  timeoutSec: number;
+  requiresApproval: boolean;
+  fieldValues: Record<string, string>;
+  command?: string;
+  url?: string;
+}
+
+export type McpRegistryInstallResult =
+  | {
+      type: "stdio";
+      name: string;
+      command: string;
+      env: Record<string, string>;
+      timeoutSec: number;
+      requiresApproval: boolean;
+    }
+  | {
+      type: "http";
+      name: string;
+      url: string;
+      headers: Record<string, string>;
+      timeoutSec: number;
+      requiresApproval: boolean;
+    };
+
+let cachedExtensions: McpRegistryExtension[] | null = null;
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function extractTemplateVariables(template: string): string[] {
+  const matches = template.matchAll(/\{([a-zA-Z_][a-zA-Z0-9_-]*)\}/g);
+  return Array.from(new Set(Array.from(matches, (match) => match[1])));
+}
+
+function resolveTemplate(
+  template: string,
+  values: Record<string, string>,
+): string {
+  return template.replace(/\{([a-zA-Z_][a-zA-Z0-9_-]*)\}/g, (full, key) => {
+    const value = values[key];
+    return value === undefined ? full : value;
+  });
+}
+
+function inferRuntimeHint(registryType?: string): string | undefined {
+  if (registryType === "npm") return "npx";
+  if (registryType === "pypi") return "uvx";
+  if (registryType === "oci") return "docker";
+  return undefined;
+}
+
+function normalizeInputField(
+  kind: InstallFieldKind,
+  key: string,
+  input: Record<string, unknown> | undefined,
+): RegistryInstallField {
+  return {
+    id: `${kind}:${key}`,
+    kind,
+    key,
+    label: key,
+    description: asString(input?.description),
+    required: Boolean(input?.isRequired),
+    secret: Boolean(input?.isSecret),
+    defaultValue:
+      asString(input?.value) ??
+      asString(input?.default) ??
+      asString(input?.placeholder) ??
+      "",
+    placeholder: asString(input?.placeholder),
+    choices: Array.isArray(input?.choices)
+      ? input.choices.filter(
+          (choice): choice is string => typeof choice === "string",
+        )
+      : undefined,
+  };
+}
+
+function addVariableField(
+  variableFields: Map<string, RegistryInstallField>,
+  key: string,
+  input?: Record<string, unknown>,
+) {
+  if (variableFields.has(key)) {
+    return;
+  }
+
+  variableFields.set(key, {
+    id: `variable:${key}`,
+    kind: "variable",
+    key,
+    label: key,
+    description: asString(input?.description),
+    required: Boolean(input?.isRequired),
+    secret: Boolean(input?.isSecret),
+    defaultValue:
+      asString(input?.value) ??
+      asString(input?.default) ??
+      asString(input?.placeholder) ??
+      "",
+    placeholder: asString(input?.placeholder),
+    choices: Array.isArray(input?.choices)
+      ? input.choices.filter(
+          (choice): choice is string => typeof choice === "string",
+        )
+      : undefined,
+  });
+}
+
+function toCommandArgumentToken(
+  arg: Record<string, unknown>,
+  variableFields: Map<string, RegistryInstallField>,
+): string | null {
+  const argType = asString(arg.type);
+  const name = asString(arg.name);
+  const value = asString(arg.value);
+  const defaultValue = asString(arg.default);
+  const valueHint = asString(arg.valueHint);
+
+  if (valueHint && arg.variables && typeof arg.variables === "object") {
+    const variablesRecord = arg.variables as Record<string, unknown>;
+    const variableConfig = variablesRecord[valueHint];
+    addVariableField(
+      variableFields,
+      valueHint,
+      variableConfig && typeof variableConfig === "object"
+        ? (variableConfig as Record<string, unknown>)
+        : undefined,
+    );
+  }
+
+  const resolvedValue =
+    value ?? defaultValue ?? (valueHint ? `{${valueHint}}` : undefined);
+
+  if (argType === "named") {
+    if (!name) return null;
+    if (resolvedValue !== undefined) {
+      return `${name}=${resolvedValue}`;
+    }
+    return name;
+  }
+
+  if (resolvedValue !== undefined) {
+    return resolvedValue;
+  }
+
+  return null;
+}
+
+function buildStdioInstallTemplate(
+  server: MCPRegistryEntry["server"],
+): McpRegistryInstallTemplate | undefined {
+  const packages = Array.isArray(server.packages) ? server.packages : [];
+  const pkg = packages.find(
+    (candidate) => candidate.transport?.type === "stdio",
+  );
+
+  if (!pkg) {
+    return undefined;
+  }
+
+  const runtimeHint =
+    asString(pkg.runtimeHint) ?? inferRuntimeHint(asString(pkg.registryType));
+  const identifier = asString(pkg.identifier);
+
+  if (!runtimeHint || !identifier) {
+    return undefined;
+  }
+
+  const variableFields = new Map<string, RegistryInstallField>();
+
+  const commandParts: string[] = [runtimeHint];
+  if (runtimeHint === "npx") {
+    commandParts.push("-y");
+  }
+  commandParts.push(identifier);
+
+  const runtimeArguments = Array.isArray(pkg.runtimeArguments)
+    ? pkg.runtimeArguments
+    : [];
+  const packageArguments = Array.isArray(pkg.packageArguments)
+    ? pkg.packageArguments
+    : [];
+
+  for (const argument of [...runtimeArguments, ...packageArguments]) {
+    if (!argument || typeof argument !== "object") {
+      continue;
+    }
+    const token = toCommandArgumentToken(
+      argument as Record<string, unknown>,
+      variableFields,
+    );
+    if (token) {
+      commandParts.push(token);
+    }
+  }
+
+  const commandTemplate = commandParts.join(" ").trim();
+
+  for (const variableName of extractTemplateVariables(commandTemplate)) {
+    if (!variableFields.has(variableName)) {
+      addVariableField(variableFields, variableName);
+    }
+  }
+
+  const envDefaults: Record<string, string> = {};
+  const envFields: RegistryInstallField[] = [];
+
+  const environmentVariables = Array.isArray(pkg.environmentVariables)
+    ? pkg.environmentVariables
+    : [];
+
+  for (const envVar of environmentVariables) {
+    if (
+      !envVar ||
+      typeof envVar !== "object" ||
+      typeof envVar.name !== "string"
+    ) {
+      continue;
+    }
+
+    const input = envVar as Record<string, unknown>;
+    const field = normalizeInputField("env", envVar.name, input);
+    envDefaults[envVar.name] = field.defaultValue;
+    envFields.push(field);
+
+    const variableNames = extractTemplateVariables(field.defaultValue);
+    for (const variableName of variableNames) {
+      if (!variableFields.has(variableName)) {
+        const variableConfig =
+          input.variables && typeof input.variables === "object"
+            ? (input.variables as Record<string, unknown>)[variableName]
+            : undefined;
+
+        addVariableField(
+          variableFields,
+          variableName,
+          variableConfig && typeof variableConfig === "object"
+            ? (variableConfig as Record<string, unknown>)
+            : undefined,
+        );
+      }
+    }
+  }
+
+  return {
+    type: "stdio",
+    commandTemplate,
+    envDefaults,
+    headerDefaults: {},
+    fields: [...variableFields.values(), ...envFields],
+  };
+}
+
+function buildHttpInstallTemplate(
+  server: MCPRegistryEntry["server"],
+): McpRegistryInstallTemplate | undefined {
+  const remotes = Array.isArray(server.remotes) ? server.remotes : [];
+  const remote = remotes.find(
+    (candidate) =>
+      candidate?.type === "streamable-http" || candidate?.type === "sse",
+  );
+
+  if (!remote || !asString(remote.url)) {
+    return undefined;
+  }
+
+  const variableFields = new Map<string, RegistryInstallField>();
+  const urlTemplate = asString(remote.url)!;
+
+  if (remote.variables && typeof remote.variables === "object") {
+    const variablesRecord = remote.variables as Record<string, unknown>;
+    for (const [key, value] of Object.entries(variablesRecord)) {
+      addVariableField(
+        variableFields,
+        key,
+        value && typeof value === "object"
+          ? (value as Record<string, unknown>)
+          : undefined,
+      );
+    }
+  }
+
+  for (const variableName of extractTemplateVariables(urlTemplate)) {
+    if (!variableFields.has(variableName)) {
+      addVariableField(variableFields, variableName);
+    }
+  }
+
+  const headerDefaults: Record<string, string> = {};
+  const headerFields: RegistryInstallField[] = [];
+
+  const headers = Array.isArray(remote.headers) ? remote.headers : [];
+  for (const header of headers) {
+    if (
+      !header ||
+      typeof header !== "object" ||
+      typeof header.name !== "string"
+    ) {
+      continue;
+    }
+
+    const input = header as Record<string, unknown>;
+    const field = normalizeInputField("header", header.name, input);
+    headerDefaults[header.name] = field.defaultValue;
+    headerFields.push(field);
+
+    const variableNames = extractTemplateVariables(field.defaultValue);
+    for (const variableName of variableNames) {
+      if (!variableFields.has(variableName)) {
+        const variableConfig =
+          input.variables && typeof input.variables === "object"
+            ? (input.variables as Record<string, unknown>)[variableName]
+            : undefined;
+
+        addVariableField(
+          variableFields,
+          variableName,
+          variableConfig && typeof variableConfig === "object"
+            ? (variableConfig as Record<string, unknown>)
+            : undefined,
+        );
+      }
+    }
+  }
+
+  return {
+    type: "http",
+    urlTemplate,
+    envDefaults: {},
+    headerDefaults,
+    fields: [...variableFields.values(), ...headerFields],
+  };
+}
+
+function buildInstallTemplate(
+  server: MCPRegistryEntry["server"],
+): McpRegistryInstallTemplate | undefined {
+  return buildStdioInstallTemplate(server) ?? buildHttpInstallTemplate(server);
+}
+
+function createSearchText(entry: McpRegistryExtension): string {
+  return [
+    entry.registryName,
+    entry.displayName,
+    entry.description,
+    entry.version,
+    entry.officialStatus,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+export function getMcpRegistryExtensions(): McpRegistryExtension[] {
+  if (cachedExtensions) {
+    return cachedExtensions;
+  }
+
+  const entries = mcpRegistryData as MCPRegistryEntry[];
+
+  cachedExtensions = entries.map((entry) => {
+    const server = entry.server;
+    const displayName =
+      asString(server.title) ?? asString(server.name) ?? "Unnamed Server";
+    const description =
+      asString(server.description) ?? "No description provided.";
+    const iconUrl =
+      Array.isArray(server.icons) && server.icons.length > 0
+        ? asString(server.icons[0]?.src)
+        : undefined;
+
+    const extension: McpRegistryExtension = {
+      id: `${server.name}@${server.version}`,
+      registryName: server.name,
+      displayName,
+      description,
+      version: server.version,
+      websiteUrl: asString(server.websiteUrl),
+      iconUrl,
+      officialStatus: asString(
+        entry._meta?.["io.modelcontextprotocol.registry/official"]?.status,
+      ),
+      updatedAt: asString(
+        entry._meta?.["io.modelcontextprotocol.registry/official"]?.updatedAt,
+      ),
+      install: buildInstallTemplate(server),
+      searchText: "",
+    };
+
+    return {
+      ...extension,
+      searchText: createSearchText(extension),
+    };
+  });
+
+  return cachedExtensions;
+}
+
+export function createMcpServerFromRegistryInstall(
+  extension: McpRegistryExtension,
+  submission: RegistryInstallSubmission,
+): McpRegistryInstallResult | null {
+  const install = extension.install;
+  if (!install) {
+    return null;
+  }
+
+  const values: Record<string, string> = {};
+
+  for (const field of install.fields) {
+    const submitted = submission.fieldValues[field.id];
+    values[field.key] = submitted ?? field.defaultValue;
+  }
+
+  const resolveConfigValue = (rawValue: string): string => {
+    return resolveTemplate(rawValue, values);
+  };
+
+  if (install.type === "stdio") {
+    const commandTemplate = submission.command ?? install.commandTemplate ?? "";
+    const command = resolveConfigValue(commandTemplate).trim();
+    if (!command) {
+      return null;
+    }
+
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(install.envDefaults)) {
+      const resolved = resolveConfigValue(value).trim();
+      if (resolved) {
+        env[key] = resolved;
+      }
+    }
+
+    for (const field of install.fields) {
+      if (field.kind !== "env") {
+        continue;
+      }
+
+      const resolved = resolveConfigValue(values[field.key] ?? "").trim();
+      if (resolved) {
+        env[field.key] = resolved;
+      } else {
+        delete env[field.key];
+      }
+    }
+
+    return {
+      type: "stdio",
+      name: submission.name.trim(),
+      command,
+      env,
+      timeoutSec: submission.timeoutSec,
+      requiresApproval: submission.requiresApproval,
+    };
+  }
+
+  const urlTemplate = submission.url ?? install.urlTemplate ?? "";
+  const url = resolveConfigValue(urlTemplate).trim();
+  if (!url) {
+    return null;
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(install.headerDefaults)) {
+    const resolved = resolveConfigValue(value).trim();
+    if (resolved) {
+      headers[key] = resolved;
+    }
+  }
+
+  for (const field of install.fields) {
+    if (field.kind !== "header") {
+      continue;
+    }
+
+    const resolved = resolveConfigValue(values[field.key] ?? "").trim();
+    if (resolved) {
+      headers[field.key] = resolved;
+    } else {
+      delete headers[field.key];
+    }
+  }
+
+  return {
+    type: "http",
+    name: submission.name.trim(),
+    url,
+    headers,
+    timeoutSec: submission.timeoutSec,
+    requiresApproval: submission.requiresApproval,
+  };
+}

--- a/src/assets/mcp-registry/mcp-registry.ts
+++ b/src/assets/mcp-registry/mcp-registry.ts
@@ -33,7 +33,15 @@ export interface McpRegistryExtension {
   version: string;
   websiteUrl?: string;
   iconUrl?: string;
-  officialStatus?: string;
+  publisher?: string;
+  categories: string[];
+  tags: string[];
+  license?: string;
+  keywords: string[];
+  packageCount: number;
+  installType?: "stdio" | "http";
+  requiredFieldCount: number;
+  transportTypes: string[];
   updatedAt?: string;
   install?: McpRegistryInstallTemplate;
   searchText: string;
@@ -70,6 +78,30 @@ let cachedExtensions: McpRegistryExtension[] | null = null;
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+
+  return asStringArray(value);
 }
 
 function extractTemplateVariables(template: string): string[] {
@@ -390,7 +422,13 @@ function createSearchText(entry: McpRegistryExtension): string {
     entry.displayName,
     entry.description,
     entry.version,
-    entry.officialStatus,
+    entry.publisher,
+    entry.license,
+    ...entry.categories,
+    ...entry.tags,
+    ...entry.keywords,
+    ...entry.transportTypes,
+    entry.installType,
   ]
     .filter(Boolean)
     .join(" ")
@@ -406,6 +444,33 @@ export function getMcpRegistryExtensions(): McpRegistryExtension[] {
 
   cachedExtensions = entries.map((entry) => {
     const server = entry.server;
+    const publisherProvided =
+      server._meta?.["io.modelcontextprotocol.registry/publisher-provided"];
+
+    const categories = Array.from(
+      new Set([
+        ...normalizeStringList(publisherProvided?.categories),
+        ...normalizeStringList(publisherProvided?.category),
+      ]),
+    );
+
+    const tags = normalizeStringList(publisherProvided?.tags);
+    const keywords = normalizeStringList(publisherProvided?.keywords);
+    const packages = Array.isArray(server.packages) ? server.packages : [];
+    const remotes = Array.isArray(server.remotes) ? server.remotes : [];
+    const transportTypes = Array.from(
+      new Set(
+        [
+          ...packages
+            .map((pkg) => asString(pkg.transport?.type))
+            .filter((item): item is string => Boolean(item)),
+          ...remotes
+            .map((remote) => asString(remote.type))
+            .filter((item): item is string => Boolean(item)),
+        ].map((transport) => transport.toLowerCase()),
+      ),
+    );
+
     const displayName =
       asString(server.title) ?? asString(server.name) ?? "Unnamed Server";
     const description =
@@ -414,6 +479,7 @@ export function getMcpRegistryExtensions(): McpRegistryExtension[] {
       Array.isArray(server.icons) && server.icons.length > 0
         ? asString(server.icons[0]?.src)
         : undefined;
+    const installTemplate = buildInstallTemplate(server);
 
     const extension: McpRegistryExtension = {
       id: `${server.name}@${server.version}`,
@@ -423,13 +489,22 @@ export function getMcpRegistryExtensions(): McpRegistryExtension[] {
       version: server.version,
       websiteUrl: asString(server.websiteUrl),
       iconUrl,
-      officialStatus: asString(
-        entry._meta?.["io.modelcontextprotocol.registry/official"]?.status,
-      ),
+      publisher:
+        asString(publisherProvided?.publisher) ??
+        asString(publisherProvided?.author),
+      categories,
+      tags,
+      license: asString(publisherProvided?.license),
+      keywords,
+      packageCount: packages.length,
+      installType: installTemplate?.type,
+      requiredFieldCount:
+        installTemplate?.fields.filter((field) => field.required).length ?? 0,
+      transportTypes,
       updatedAt: asString(
         entry._meta?.["io.modelcontextprotocol.registry/official"]?.updatedAt,
       ),
-      install: buildInstallTemplate(server),
+      install: installTemplate,
       searchText: "",
     };
 

--- a/src/assets/mcp-registry/mcp-registry.ts
+++ b/src/assets/mcp-registry/mcp-registry.ts
@@ -45,6 +45,7 @@ export interface McpRegistryExtension {
   updatedAt?: string;
   install?: McpRegistryInstallTemplate;
   searchText: string;
+  registryEntry: MCPRegistryEntry;
 }
 
 export interface RegistryInstallSubmission {
@@ -506,6 +507,7 @@ export function getMcpRegistryExtensions(): McpRegistryExtension[] {
       ),
       install: installTemplate,
       searchText: "",
+      registryEntry: entry,
     };
 
     return {

--- a/src/assets/mcp-registry/types.ts
+++ b/src/assets/mcp-registry/types.ts
@@ -20,11 +20,11 @@ export type Server = {
   description: string;
   repository?: Repository;
   version: string;
-  packages?: Package[];
-  title?: string;
   websiteUrl?: string;
-  icons?: Icon[];
   remotes?: Remote[];
+  title?: string;
+  icons?: Icon[];
+  packages?: Package[];
   _meta?: ServerMeta;
 };
 
@@ -50,8 +50,12 @@ export type IoModelcontextprotocolRegistryPublisherProvided = {
   build_info?: BuildInfoClass;
   capabilities?: string[] | CapabilitiesClass;
   tags?: string[];
-  authentication?: Authentication;
+  authentication?: AuthenticationClass | string;
   categories?: string[];
+  promptCount?: number;
+  resourceCount?: number;
+  toolCount?: number;
+  tools?: Array<ToolClass | string>;
   homepage?: string;
   author?: string;
   issues?: string;
@@ -59,7 +63,6 @@ export type IoModelcontextprotocolRegistryPublisherProvided = {
   features?: string[] | FeaturesClass;
   installationMethods?: InstallationMethod[];
   toolCategories?: ToolCategories;
-  tools?: Array<ToolClass | string>;
   buildInfo?: BuildInfo;
   contact?: string;
   rateLimit?: RateLimit;
@@ -99,7 +102,7 @@ export type Auth = {
   token_endpoint?: string;
 };
 
-export type Authentication = {
+export type AuthenticationClass = {
   description: string;
   type: string;
 };
@@ -290,10 +293,31 @@ export type EnvironmentVariable = {
 };
 
 export type EnvironmentVariableVariables = {
-  weather_choices: Endpoint;
+  weather_choices?: AgentID;
+  TRILO_PAT?: ApifyToken;
+  INFOBIP_API_KEY?: ApifyToken;
+  YUOR_MCP_TOKEN?: ApifyToken;
+  api_key?: ApifyToken;
+  indicate_api_key?: ApifyToken;
+  NETDATA_CLOUD_API_TOKEN?: SgpDirectoryAPIKey;
 };
 
-export type Endpoint = {
+export type ApifyToken = {
+  description?: string;
+  isRequired?: boolean;
+  format?: string;
+  isSecret?: boolean;
+  default?: string;
+  placeholder?: string;
+  choices?: string[];
+};
+
+export type SgpDirectoryAPIKey = {
+  description: string;
+  isSecret: boolean;
+};
+
+export type AgentID = {
   description: string;
   isRequired?: boolean;
 };
@@ -340,7 +364,7 @@ export type RuntimeArgument = {
 
 export type RuntimeArgumentVariables = {
   source_path?: ApifyToken;
-  workspace?: Endpoint;
+  workspace?: AgentID;
   host_port?: HostPort;
   network?: HostPort;
   api_key?: ApifyToken;
@@ -348,28 +372,18 @@ export type RuntimeArgumentVariables = {
   encoder_file?: ApifyToken;
   decoder_file?: ApifyToken;
   tokens_file?: ApifyToken;
+  token?: ApifyToken;
   config_path?: ApifyToken;
   data_path?: ApifyToken;
   workspace_path?: ApifyToken;
-  group?: CompanyCode;
-  user?: CompanyCode;
-  hostPath?: CompanyCode;
-  token?: ApifyToken;
+  group?: APIKey;
+  user?: APIKey;
+  hostPath?: APIKey;
   host?: Instance;
   port?: ApifyToken;
 };
 
-export type ApifyToken = {
-  description?: string;
-  isRequired?: boolean;
-  format?: string;
-  isSecret?: boolean;
-  default?: string;
-  placeholder?: string;
-  choices?: string[];
-};
-
-export type CompanyCode = {
+export type APIKey = {
   description: string;
 };
 
@@ -381,49 +395,14 @@ export type HostPort = {
 export type Transport = {
   type: string;
   url?: string;
-  headers?: TransportHeader[];
-};
-
-export type TransportHeader = {
-  description: string;
-  format?: string;
-  isSecret?: boolean;
-  name: string;
-  default?: string;
-  choices?: string[];
-  isRequired?: boolean;
+  headers?: EnvironmentVariable[];
 };
 
 export type Remote = {
   type: string;
   url: string;
-  headers?: RemoteHeader[];
+  headers?: EnvironmentVariable[];
   variables?: RemoteVariables;
-};
-
-export type RemoteHeader = {
-  description?: string;
-  isRequired?: boolean;
-  format?: string;
-  isSecret?: boolean;
-  name: string;
-  value?: string;
-  placeholder?: string;
-  variables?: HeaderVariables;
-  default?: string;
-  choices?: string[];
-};
-
-export type HeaderVariables = {
-  INFOBIP_API_KEY?: ApifyToken;
-  YUOR_MCP_TOKEN?: ApifyToken;
-  api_key?: ApifyToken;
-  NETDATA_CLOUD_API_TOKEN?: NetdataCloudAPIToken;
-};
-
-export type NetdataCloudAPIToken = {
-  description: string;
-  isSecret: boolean;
 };
 
 export type RemoteVariables = {
@@ -431,25 +410,37 @@ export type RemoteVariables = {
   HAPI_PORT?: ApifyToken;
   instance?: Instance;
   baseUrl?: ApifyToken;
-  "server-name"?: Endpoint;
+  "server-name"?: AgentID;
   env?: ApifyToken;
+  agent_id?: AgentID;
   api_key?: ApifyToken;
   region?: ApifyToken;
   qovery_token?: ApifyToken;
+  SGP_DIRECTORY_API_KEY?: SgpDirectoryAPIKey;
   token?: ApifyToken;
+  AUTH_TOKEN?: ApifyToken;
   tenant_id?: Instance;
-  company_code?: CompanyCode;
+  API_KEY?: APIKey;
+  company_code?: APIKey;
   BILT_API_KEY?: ApifyToken;
-  site_key?: Endpoint;
+  site_key?: AgentID;
+  oauth_client_id?: OauthClientID;
+  oauth_client_secret?: ApifyToken;
   APIFY_TOKEN?: ApifyToken;
-  your_mcp_server_host?: Endpoint;
-  endpoint?: Endpoint;
+  your_mcp_server_host?: AgentID;
+  lobster_id?: AgentID;
+  endpoint?: AgentID;
   api_token?: ApifyToken;
+};
+
+export type OauthClientID = {
+  description: string;
+  value: string;
 };
 
 export type Repository = {
   url?: string;
   source?: string;
-  subfolder?: string;
   id?: string;
+  subfolder?: string;
 };

--- a/src/components/a1/empty-states/no-custom-extensions.tsx
+++ b/src/components/a1/empty-states/no-custom-extensions.tsx
@@ -1,6 +1,6 @@
 export const NoCustomExtensions = () => {
   return (
-    <div className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
+    <div className="text-muted-foreground rounded-md border border-dashed p-8 text-center text-sm">
       No custom extensions yet. Click &quot;Add Custom&quot; to create one.
     </div>
   );

--- a/src/components/a1/empty-states/no-custom-extensions.tsx
+++ b/src/components/a1/empty-states/no-custom-extensions.tsx
@@ -1,7 +1,7 @@
-export const NoMcpServers = () => {
+export const NoCustomExtensions = () => {
   return (
     <div className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
-      No MCP servers configured. Click &quot;Add Server&quot; to get started.
+      No custom extensions yet. Click &quot;Add Custom&quot; to create one.
     </div>
   );
 };

--- a/src/routes/onboarding/steps/account.tsx
+++ b/src/routes/onboarding/steps/account.tsx
@@ -106,7 +106,7 @@ export function AccountStep({ onSubmit }: AccountStepProps) {
         </div>
 
         <div className="flex flex-col gap-4">
-          <div className="border-border rounded-lg border p-4">
+          <div className="border-border rounded-md border p-4">
             <AuthStatusDisplay />
           </div>
 

--- a/src/routes/settings/sections-metadata.ts
+++ b/src/routes/settings/sections-metadata.ts
@@ -6,7 +6,7 @@ export const sectionsMetadata = [
   { id: "messages", label: "Messages" },
   { id: "titles", label: "Titles" },
   { id: "tools", label: "Tools" },
-  { id: "mcp", label: "MCP Servers" },
+  { id: "mcp", label: "Extensions" },
   { id: "streaming", label: "Streaming" },
   { id: "about", label: "About" },
 ] as const;

--- a/src/routes/settings/sections/mcp/add-server-dialog.tsx
+++ b/src/routes/settings/sections/mcp/add-server-dialog.tsx
@@ -100,9 +100,9 @@ export function AddServerDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Add MCP Server</DialogTitle>
+          <DialogTitle>Add Custom Extension</DialogTitle>
           <DialogDescription>
-            Configure a new MCP server to extend the AI&apos;s capabilities.
+            Configure a custom extension by defining an MCP server.
           </DialogDescription>
         </DialogHeader>
 
@@ -215,7 +215,7 @@ export function AddServerDialog({
             Cancel
           </Button>
           <Button onClick={handleAddServer} disabled={!isAddFormValid}>
-            Add Server
+            Add Custom
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/routes/settings/sections/mcp/extension-advanced-details.tsx
+++ b/src/routes/settings/sections/mcp/extension-advanced-details.tsx
@@ -1,0 +1,132 @@
+import { EnvVarsEditor } from "@/components/a1/input/env-vars-editor";
+import { HttpHeadersEditor } from "@/components/a1/input/http-headers-editor";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { type McpServerConfig } from "@/lib/settings/types";
+
+import { McpAuthStatus } from "./mcp-auth-status";
+
+interface ExtensionAdvancedDetailsProps {
+  server: McpServerConfig;
+  onUpdate: (updates: Partial<McpServerConfig>) => void;
+}
+
+export function ExtensionAdvancedDetails({
+  server,
+  onUpdate,
+}: ExtensionAdvancedDetailsProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <Label htmlFor={`enabled-${server.id}`} className="text-sm">
+            Enabled
+          </Label>
+          <span className="text-muted-foreground text-xs">
+            Load this extension when tools initialize
+          </span>
+        </div>
+        <Switch
+          id={`enabled-${server.id}`}
+          checked={server.enabled}
+          onCheckedChange={(checked) => onUpdate({ enabled: checked })}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="grid flex-1 gap-1.5">
+          <Label htmlFor={`name-${server.id}`} className="text-xs">
+            Name
+          </Label>
+          <Input
+            id={`name-${server.id}`}
+            value={server.name}
+            onChange={(event) => onUpdate({ name: event.target.value })}
+            placeholder="Extension name"
+          />
+        </div>
+
+        <div className="grid gap-1.5 sm:w-32">
+          <Label htmlFor={`timeout-${server.id}`} className="text-xs">
+            Timeout (sec)
+          </Label>
+          <Input
+            id={`timeout-${server.id}`}
+            type="number"
+            min="1"
+            max="300"
+            value={Math.round(server.timeoutMs / 1000)}
+            onChange={(event) =>
+              onUpdate({
+                timeoutMs: (parseInt(event.target.value) || 30) * 1000,
+              })
+            }
+            placeholder="30"
+          />
+        </div>
+      </div>
+
+      {server.type === "stdio" ? (
+        <>
+          <div className="grid gap-1.5">
+            <Label htmlFor={`command-${server.id}`} className="text-xs">
+              Command
+            </Label>
+            <Input
+              id={`command-${server.id}`}
+              value={server.command}
+              onChange={(event) => onUpdate({ command: event.target.value })}
+              placeholder="e.g., npx -y @modelcontextprotocol/server-everything"
+            />
+          </div>
+          <EnvVarsEditor
+            id={server.id}
+            env={server.env}
+            onChange={(env) => onUpdate({ env })}
+          />
+        </>
+      ) : (
+        <>
+          <div className="grid gap-1.5">
+            <Label htmlFor={`url-${server.id}`} className="text-xs">
+              URL
+            </Label>
+            <Input
+              id={`url-${server.id}`}
+              value={server.url}
+              onChange={(event) => onUpdate({ url: event.target.value })}
+              placeholder="https://mcp.example.com/api"
+            />
+          </div>
+          <McpAuthStatus server={server} disabled={!server.enabled} />
+          <HttpHeadersEditor
+            id={server.id}
+            headers={server.headers}
+            onChange={(headers) => onUpdate({ headers })}
+          />
+        </>
+      )}
+
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <Label htmlFor={`approval-${server.id}`} className="text-sm">
+            Require Approval
+          </Label>
+          <span className="text-muted-foreground text-xs">
+            Ask for confirmation before running tools
+          </span>
+        </div>
+        <Switch
+          id={`approval-${server.id}`}
+          checked={server.requiresApproval ?? false}
+          onCheckedChange={(checked) =>
+            onUpdate({
+              requiresApproval: checked,
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/routes/settings/sections/mcp/extension-advanced-details.tsx
+++ b/src/routes/settings/sections/mcp/extension-advanced-details.tsx
@@ -54,14 +54,16 @@ export function ExtensionAdvancedDetails({
           <Input
             id={`timeout-${server.id}`}
             type="number"
-            min="1"
+            min="0.1"
             max="300"
-            value={Math.round(server.timeoutMs / 1000)}
-            onChange={(event) =>
+            step="0.1"
+            value={server.timeoutMs / 1000}
+            onChange={(event) => {
+              const seconds = parseFloat(event.target.value);
               onUpdate({
-                timeoutMs: (parseInt(event.target.value) || 30) * 1000,
-              })
-            }
+                timeoutMs: seconds * 1000,
+              });
+            }}
             placeholder="30"
           />
         </div>

--- a/src/routes/settings/sections/mcp/extension-list-row.tsx
+++ b/src/routes/settings/sections/mcp/extension-list-row.tsx
@@ -2,6 +2,12 @@ import { ChevronRightIcon, ExternalLinkIcon, Trash2Icon } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
 
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -37,7 +43,7 @@ interface ExtensionListRowProps {
   onInstall?: () => void;
   onUninstall?: () => void;
   advancedContent?: ReactNode;
-  moreInfoContent?: ReactNode;
+  moreInfoJson?: unknown;
 }
 
 export function ExtensionListRow({
@@ -52,9 +58,9 @@ export function ExtensionListRow({
   onInstall,
   onUninstall,
   advancedContent,
-  moreInfoContent,
+  moreInfoJson,
 }: ExtensionListRowProps) {
-  const hasAdvanced = Boolean(advancedContent) || Boolean(moreInfoContent);
+  const hasAdvanced = Boolean(advancedContent) || moreInfoJson !== undefined;
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
   return (
@@ -138,11 +144,23 @@ export function ExtensionListRow({
             </DialogHeader>
             <div className="flex flex-col gap-4 py-1">
               {advancedContent}
-              {moreInfoContent ? (
-                <div className="flex flex-col gap-3 rounded-md border p-3">
-                  <p className="text-sm font-medium">More info</p>
-                  {moreInfoContent}
-                </div>
+              {moreInfoJson !== undefined ? (
+                <Accordion
+                  type="single"
+                  collapsible
+                  className="rounded-md border px-3"
+                >
+                  <AccordionItem value="more-info" className="border-b-0">
+                    <AccordionTrigger className="py-3">
+                      Debug info
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <pre className="bg-muted overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
+                        {JSON.stringify(moreInfoJson, null, 2)}
+                      </pre>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
               ) : null}
             </div>
           </DialogContent>

--- a/src/routes/settings/sections/mcp/extension-list-row.tsx
+++ b/src/routes/settings/sections/mcp/extension-list-row.tsx
@@ -115,10 +115,7 @@ export function ExtensionListRow({
 
       {installed && hasAdvanced ? (
         <Accordion type="single" collapsible>
-          <AccordionItem
-            value="advanced"
-            className="border-border rounded-md border px-3"
-          >
+          <AccordionItem value="advanced" className="px-3 last:border-b">
             <AccordionTrigger className="py-3">Advanced</AccordionTrigger>
             <AccordionContent>
               <div className="flex flex-col gap-3">
@@ -127,7 +124,7 @@ export function ExtensionListRow({
                   <Accordion type="single" collapsible>
                     <AccordionItem
                       value="more-info"
-                      className="border-border rounded-md border px-3"
+                      className="px-3 last:border-b"
                     >
                       <AccordionTrigger className="py-3">
                         More info

--- a/src/routes/settings/sections/mcp/extension-list-row.tsx
+++ b/src/routes/settings/sections/mcp/extension-list-row.tsx
@@ -115,18 +115,21 @@ export function ExtensionListRow({
 
       {installed && hasAdvanced ? (
         <Accordion type="single" collapsible>
-          <AccordionItem value="advanced" className="px-3 last:border-b">
-            <AccordionTrigger className="py-3">Advanced</AccordionTrigger>
-            <AccordionContent>
+          <AccordionItem
+            value="advanced"
+            className="rounded-md border border-b! px-2"
+          >
+            <AccordionTrigger className="py-2">Advanced</AccordionTrigger>
+            <AccordionContent className="pb-3">
               <div className="flex flex-col gap-3">
                 {advancedContent}
                 {moreInfoContent ? (
                   <Accordion type="single" collapsible>
                     <AccordionItem
                       value="more-info"
-                      className="px-3 last:border-b"
+                      className="rounded-md border border-b! px-2"
                     >
-                      <AccordionTrigger className="py-3">
+                      <AccordionTrigger className="py-2">
                         More info
                       </AccordionTrigger>
                       <AccordionContent>{moreInfoContent}</AccordionContent>

--- a/src/routes/settings/sections/mcp/extension-list-row.tsx
+++ b/src/routes/settings/sections/mcp/extension-list-row.tsx
@@ -1,15 +1,18 @@
-import { ExternalLinkIcon, Trash2Icon } from "lucide-react";
+import { ChevronRightIcon, ExternalLinkIcon, Trash2Icon } from "lucide-react";
 import type { ReactNode } from "react";
+import { useState } from "react";
 
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
 function getInitials(name: string): string {
   const words = name.trim().split(/\s+/).filter(Boolean);
@@ -52,6 +55,7 @@ export function ExtensionListRow({
   moreInfoContent,
 }: ExtensionListRowProps) {
   const hasAdvanced = Boolean(advancedContent) || Boolean(moreInfoContent);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   return (
     <div className="flex w-full flex-col gap-3 rounded-md border p-4">
@@ -114,32 +118,35 @@ export function ExtensionListRow({
       </div>
 
       {installed && hasAdvanced ? (
-        <Accordion type="single" collapsible>
-          <AccordionItem
-            value="advanced"
-            className="rounded-md border border-b! px-2"
-          >
-            <AccordionTrigger className="py-2">Advanced</AccordionTrigger>
-            <AccordionContent className="pb-3">
-              <div className="flex flex-col gap-3">
-                {advancedContent}
-                {moreInfoContent ? (
-                  <Accordion type="single" collapsible>
-                    <AccordionItem
-                      value="more-info"
-                      className="rounded-md border border-b! px-2"
-                    >
-                      <AccordionTrigger className="py-2">
-                        More info
-                      </AccordionTrigger>
-                      <AccordionContent>{moreInfoContent}</AccordionContent>
-                    </AccordionItem>
-                  </Accordion>
-                ) : null}
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+        <Dialog open={advancedOpen} onOpenChange={setAdvancedOpen}>
+          <DialogTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-auto w-full justify-between rounded-md border px-3 py-2 text-sm font-medium"
+            >
+              Advanced
+              <ChevronRightIcon className="text-muted-foreground size-4" />
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>{title} advanced config</DialogTitle>
+              <DialogDescription>
+                Edit advanced settings for this extension.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col gap-4 py-1">
+              {advancedContent}
+              {moreInfoContent ? (
+                <div className="flex flex-col gap-3 rounded-md border p-3">
+                  <p className="text-sm font-medium">More info</p>
+                  {moreInfoContent}
+                </div>
+              ) : null}
+            </div>
+          </DialogContent>
+        </Dialog>
       ) : null}
     </div>
   );

--- a/src/routes/settings/sections/mcp/extension-list-row.tsx
+++ b/src/routes/settings/sections/mcp/extension-list-row.tsx
@@ -1,0 +1,146 @@
+import { ExternalLinkIcon, Trash2Icon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return "EX";
+  }
+  if (words.length === 1) {
+    return words[0].slice(0, 2).toUpperCase();
+  }
+  return `${words[0][0]}${words[1][0]}`.toUpperCase();
+}
+
+interface ExtensionListRowProps {
+  title: string;
+  description: string;
+  version?: string;
+  iconUrl?: string;
+  websiteUrl?: string;
+  badges?: string[];
+  installed: boolean;
+  installSupported?: boolean;
+  onInstall?: () => void;
+  onUninstall?: () => void;
+  advancedContent?: ReactNode;
+  moreInfoContent?: ReactNode;
+}
+
+export function ExtensionListRow({
+  title,
+  description,
+  version,
+  iconUrl,
+  websiteUrl,
+  badges = [],
+  installed,
+  installSupported = true,
+  onInstall,
+  onUninstall,
+  advancedContent,
+  moreInfoContent,
+}: ExtensionListRowProps) {
+  const hasAdvanced = Boolean(advancedContent) || Boolean(moreInfoContent);
+
+  return (
+    <div className="flex w-full flex-col gap-3 rounded-md border p-4">
+      <div className="flex w-full items-start gap-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="flex min-w-0 items-center gap-2 truncate text-lg font-medium">
+              <Avatar className="size-6">
+                <AvatarImage src={iconUrl} alt={`${title} icon`} />
+                <AvatarFallback className="text-[0.7em]">
+                  {getInitials(title)}
+                </AvatarFallback>
+              </Avatar>
+              <span className="truncate">{title}</span>
+            </p>
+            {version ? <Badge variant="outline">v{version}</Badge> : null}
+          </div>
+
+          <p className="text-muted-foreground line-clamp-2 text-xs">
+            {description}
+          </p>
+
+          {badges.length > 0 ? (
+            <div className="text-muted-foreground flex min-w-0 flex-wrap items-center gap-2 text-xs">
+              {badges.slice(0, 2).map((tag) => (
+                <Badge key={`${title}-${tag}`} variant="outline">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          {websiteUrl ? (
+            <Button variant="outline" size="sm" asChild>
+              <a href={websiteUrl} target="_blank" rel="noreferrer">
+                <ExternalLinkIcon className="size-4" />
+                Website
+              </a>
+            </Button>
+          ) : null}
+
+          {installed ? (
+            <Button size="sm" variant="destructive" onClick={onUninstall}>
+              <Trash2Icon className="size-4" />
+              Uninstall
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="default"
+              onClick={onInstall}
+              disabled={!installSupported}
+            >
+              {installSupported ? "Install" : "Unsupported"}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {installed && hasAdvanced ? (
+        <Accordion type="single" collapsible>
+          <AccordionItem
+            value="advanced"
+            className="border-border rounded-md border px-3"
+          >
+            <AccordionTrigger className="py-3">Advanced</AccordionTrigger>
+            <AccordionContent>
+              <div className="flex flex-col gap-3">
+                {advancedContent}
+                {moreInfoContent ? (
+                  <Accordion type="single" collapsible>
+                    <AccordionItem
+                      value="more-info"
+                      className="border-border rounded-md border px-3"
+                    >
+                      <AccordionTrigger className="py-3">
+                        More info
+                      </AccordionTrigger>
+                      <AccordionContent>{moreInfoContent}</AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                ) : null}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      ) : null}
+    </div>
+  );
+}

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -49,19 +49,20 @@ function ExtensionRow({
   onUninstall: () => void;
 }) {
   return (
-    <div className="flex w-full items-start gap-4 rounded-md border p-4">
-      <Avatar size="sm">
-        <AvatarImage
-          src={extension.iconUrl}
-          alt={`${extension.displayName} icon`}
-        />
-        <AvatarFallback>{getInitials(extension.displayName)}</AvatarFallback>
-      </Avatar>
-
+    <div className="flex w-full items-start gap-3 rounded-md border p-4">
       <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="flex min-w-0 items-center gap-2">
-          <p className="truncate text-sm font-medium">
-            {extension.displayName}
+          <p className="flex min-w-0 items-center gap-2 truncate text-lg font-medium">
+            <Avatar className="size-6">
+              <AvatarImage
+                src={extension.iconUrl}
+                alt={`${extension.displayName} icon`}
+              />
+              <AvatarFallback className="text-[0.7em]">
+                {getInitials(extension.displayName)}
+              </AvatarFallback>
+            </Avatar>
+            <span className="truncate">{extension.displayName}</span>
           </p>
           <Badge variant="outline">v{extension.version}</Badge>
         </div>

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -1,0 +1,183 @@
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { SearchIcon, SparklesIcon } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+
+import {
+  getMcpRegistryExtensions,
+  type McpRegistryExtension,
+} from "@/assets/mcp-registry/mcp-registry";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const EXTENSION_ITEM_HEIGHT = 106;
+
+interface ExtensionsBrowserProps {
+  installedRegistryNames: Set<string>;
+  onInstallClick: (extension: McpRegistryExtension) => void;
+}
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return "EX";
+  }
+  if (words.length === 1) {
+    return words[0].slice(0, 2).toUpperCase();
+  }
+  return `${words[0][0]}${words[1][0]}`.toUpperCase();
+}
+
+function ExtensionRow({
+  extension,
+  installed,
+  onInstall,
+}: {
+  extension: McpRegistryExtension;
+  installed: boolean;
+  onInstall: () => void;
+}) {
+  return (
+    <div className="flex h-full items-start justify-between gap-3 border-b px-3 py-3">
+      <Avatar className="mt-0.5" size="sm">
+        <AvatarImage
+          src={extension.iconUrl}
+          alt={`${extension.displayName} icon`}
+        />
+        <AvatarFallback>{getInitials(extension.displayName)}</AvatarFallback>
+      </Avatar>
+
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-center gap-2">
+          <p className="truncate text-sm font-medium">
+            {extension.displayName}
+          </p>
+          <Badge variant="outline">v{extension.version}</Badge>
+          {extension.officialStatus === "active" ? (
+            <Badge className="bg-emerald-600 hover:bg-emerald-600">
+              Official
+            </Badge>
+          ) : null}
+        </div>
+        <p className="text-muted-foreground line-clamp-2 text-xs">
+          {extension.description}
+        </p>
+        <p className="text-muted-foreground mt-1 truncate text-xs">
+          {extension.registryName}
+        </p>
+      </div>
+      <Button
+        size="sm"
+        variant={installed ? "outline" : "default"}
+        onClick={onInstall}
+        disabled={installed || !extension.install}
+      >
+        {installed
+          ? "Installed"
+          : extension.install
+            ? "Install"
+            : "Unsupported"}
+      </Button>
+    </div>
+  );
+}
+
+export function ExtensionsBrowser({
+  installedRegistryNames,
+  onInstallClick,
+}: ExtensionsBrowserProps) {
+  const [query, setQuery] = useState("");
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const extensions = useMemo(() => getMcpRegistryExtensions(), []);
+
+  const filteredExtensions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return extensions;
+    }
+    return extensions.filter((extension) =>
+      extension.searchText.includes(normalizedQuery),
+    );
+  }, [extensions, query]);
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const virtualizer = useVirtualizer({
+    count: filteredExtensions.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => EXTENSION_ITEM_HEIGHT,
+    overscan: 6,
+  });
+
+  const listHeight = Math.min(
+    filteredExtensions.length * EXTENSION_ITEM_HEIGHT,
+    420,
+  );
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border p-3">
+      <div className="flex items-center gap-2">
+        <SparklesIcon className="text-muted-foreground size-4" />
+        <p className="text-sm font-medium">Extensions Registry</p>
+      </div>
+
+      <div className="relative">
+        <SearchIcon className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search extensions"
+          className="pl-9"
+        />
+      </div>
+
+      {filteredExtensions.length > 0 ? (
+        <div
+          ref={parentRef}
+          className="border-border overflow-y-auto rounded-md border"
+          style={{ height: listHeight || EXTENSION_ITEM_HEIGHT }}
+        >
+          <div
+            style={{
+              height: `${virtualizer.getTotalSize()}px`,
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualItem) => {
+              const extension = filteredExtensions[virtualItem.index];
+              const installed = installedRegistryNames.has(
+                extension.registryName,
+              );
+
+              return (
+                <div
+                  key={extension.id}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: `${virtualItem.size}px`,
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  <ExtensionRow
+                    extension={extension}
+                    installed={installed}
+                    onInstall={() => onInstallClick(extension)}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : (
+        <div className="text-muted-foreground flex h-20 items-center justify-center rounded-md border border-dashed text-sm">
+          No extensions match your search.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -68,10 +68,11 @@ function ExtensionRow({
         </p>
 
         <div className="text-muted-foreground flex min-w-0 flex-wrap items-center gap-2 text-xs">
-          <span className="truncate">{extension.registryName}</span>
           {extension.publisher ? (
             <span className="truncate">by {extension.publisher}</span>
-          ) : null}
+          ) : (
+            <span>Community extension</span>
+          )}
           {(extension.categories.length > 0
             ? extension.categories
             : extension.tags

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -83,10 +83,7 @@ export function ExtensionsBrowser({
         onValueChange={setQuery}
         placeholder="Search extensions..."
       />
-      <CommandList
-        ref={parentRef}
-        className="max-h-[75svh] rounded-none border-0"
-      >
+      <CommandList ref={parentRef} className="max-h-96 rounded-none border-0">
         {filteredExtensions.length === 0 ? (
           <CommandEmpty className="h-full py-3">
             <div className="text-muted-foreground rounded-md p-8 text-center text-sm">

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -64,9 +64,6 @@ function ExtensionRow({
             {extension.displayName}
           </p>
           <Badge variant="outline">v{extension.version}</Badge>
-          {!extension.publisher ? (
-            <Badge variant="secondary">Community</Badge>
-          ) : null}
         </div>
 
         <p className="text-muted-foreground line-clamp-2 text-xs">
@@ -74,9 +71,6 @@ function ExtensionRow({
         </p>
 
         <div className="text-muted-foreground flex min-w-0 flex-wrap items-center gap-2 text-xs">
-          {extension.publisher ? (
-            <span className="truncate">by {extension.publisher}</span>
-          ) : null}
           {(extension.categories.length > 0
             ? extension.categories
             : extension.tags

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -77,7 +77,7 @@ export function ExtensionsBrowser({
   });
 
   return (
-    <Command shouldFilter={false} className="bg-transparent">
+    <Command shouldFilter={false} className="border">
       <CommandInput
         value={query}
         onValueChange={setQuery}

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -1,14 +1,11 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ExternalLinkIcon, Trash2Icon } from "lucide-react";
+import type { ReactNode } from "react";
 import { useMemo, useRef, useState } from "react";
 
 import {
   getMcpRegistryExtensions,
   type McpRegistryExtension,
 } from "@/assets/mcp-registry/mcp-registry";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Command,
   CommandEmpty,
@@ -18,107 +15,26 @@ import {
 } from "@/components/ui/command";
 import { commandScore } from "@/lib/command-score";
 
+import { ExtensionListRow } from "./extension-list-row";
+
 const ESTIMATED_EXTENSION_ITEM_HEIGHT = 148;
 
 interface ExtensionsBrowserProps {
+  filter?: "all" | "installed";
   isInstalled: (extension: McpRegistryExtension) => boolean;
   onInstallClick: (extension: McpRegistryExtension) => void;
   onUninstallClick: (extension: McpRegistryExtension) => void;
-}
-
-function getInitials(name: string): string {
-  const words = name.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) {
-    return "EX";
-  }
-  if (words.length === 1) {
-    return words[0].slice(0, 2).toUpperCase();
-  }
-  return `${words[0][0]}${words[1][0]}`.toUpperCase();
-}
-
-function ExtensionRow({
-  extension,
-  installed,
-  onInstall,
-  onUninstall,
-}: {
-  extension: McpRegistryExtension;
-  installed: boolean;
-  onInstall: () => void;
-  onUninstall: () => void;
-}) {
-  return (
-    <div className="flex w-full items-start gap-3 rounded-md border p-4">
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <p className="flex min-w-0 items-center gap-2 truncate text-lg font-medium">
-            <Avatar className="size-6">
-              <AvatarImage
-                src={extension.iconUrl}
-                alt={`${extension.displayName} icon`}
-              />
-              <AvatarFallback className="text-[0.7em]">
-                {getInitials(extension.displayName)}
-              </AvatarFallback>
-            </Avatar>
-            <span className="truncate">{extension.displayName}</span>
-          </p>
-          <Badge variant="outline">v{extension.version}</Badge>
-        </div>
-
-        <p className="text-muted-foreground line-clamp-2 text-xs">
-          {extension.description}
-        </p>
-
-        <div className="text-muted-foreground flex min-w-0 flex-wrap items-center gap-2 text-xs">
-          {(extension.categories.length > 0
-            ? extension.categories
-            : extension.tags
-          )
-            .slice(0, 2)
-            .map((tag) => (
-              <Badge key={`${extension.id}-${tag}`} variant="outline">
-                {tag}
-              </Badge>
-            ))}
-        </div>
-      </div>
-
-      <div className="flex shrink-0 items-center gap-2">
-        {extension.websiteUrl ? (
-          <Button variant="outline" size="sm" asChild>
-            <a href={extension.websiteUrl} target="_blank" rel="noreferrer">
-              <ExternalLinkIcon className="size-4" />
-              Website
-            </a>
-          </Button>
-        ) : null}
-
-        {installed ? (
-          <Button size="sm" variant="destructive" onClick={onUninstall}>
-            <Trash2Icon className="size-4" />
-            Uninstall
-          </Button>
-        ) : (
-          <Button
-            size="sm"
-            variant="default"
-            onClick={onInstall}
-            disabled={!extension.install}
-          >
-            {extension.install ? "Install" : "Unsupported"}
-          </Button>
-        )}
-      </div>
-    </div>
-  );
+  getAdvancedContent?: (extension: McpRegistryExtension) => ReactNode;
+  getMoreInfoContent?: (extension: McpRegistryExtension) => ReactNode;
 }
 
 export function ExtensionsBrowser({
+  filter = "all",
   isInstalled,
   onInstallClick,
   onUninstallClick,
+  getAdvancedContent,
+  getMoreInfoContent,
 }: ExtensionsBrowserProps) {
   const [query, setQuery] = useState("");
   const parentRef = useRef<HTMLDivElement>(null);
@@ -127,11 +43,17 @@ export function ExtensionsBrowser({
 
   const filteredExtensions = useMemo(() => {
     const normalizedQuery = query.trim();
+
+    const baseExtensions =
+      filter === "installed"
+        ? extensions.filter((extension) => isInstalled(extension))
+        : extensions;
+
     if (!normalizedQuery) {
-      return extensions;
+      return baseExtensions;
     }
 
-    return extensions
+    return baseExtensions
       .map((extension) => ({
         extension,
         score: commandScore(extension.displayName, normalizedQuery, [
@@ -142,7 +64,7 @@ export function ExtensionsBrowser({
       .filter(({ score }) => score > 0)
       .sort((a, b) => b.score - a.score)
       .map(({ extension }) => extension);
-  }, [extensions, query]);
+  }, [extensions, filter, isInstalled, query]);
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
@@ -154,17 +76,8 @@ export function ExtensionsBrowser({
     overscan: 6,
   });
 
-  const totalSize = virtualizer.getTotalSize();
-  const listHeight = Math.min(
-    totalSize || ESTIMATED_EXTENSION_ITEM_HEIGHT,
-    420,
-  );
-
   return (
-    <Command
-      shouldFilter={false}
-      className="border-border rounded-md border bg-transparent"
-    >
+    <Command shouldFilter={false} className="bg-transparent">
       <CommandInput
         value={query}
         onValueChange={setQuery}
@@ -172,12 +85,15 @@ export function ExtensionsBrowser({
       />
       <CommandList
         ref={parentRef}
-        className="rounded-none border-0"
-        style={{ height: listHeight }}
+        className="h-[60vh] max-h-[52rem] min-h-[26rem] rounded-none border-0"
       >
         {filteredExtensions.length === 0 ? (
-          <CommandEmpty className="flex h-full items-center justify-center py-0 text-center">
-            No extensions match your search.
+          <CommandEmpty className="h-full py-3">
+            <div className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
+              {filter === "installed"
+                ? "No installed extensions match your search."
+                : "No extensions match your search."}
+            </div>
           </CommandEmpty>
         ) : (
           <CommandGroup className="p-2">
@@ -206,11 +122,31 @@ export function ExtensionsBrowser({
                     }}
                   >
                     <div className="py-1">
-                      <ExtensionRow
-                        extension={extension}
+                      <ExtensionListRow
+                        title={extension.displayName}
+                        description={extension.description}
+                        version={extension.version}
+                        iconUrl={extension.iconUrl}
+                        websiteUrl={extension.websiteUrl}
+                        badges={
+                          extension.categories.length > 0
+                            ? extension.categories
+                            : extension.tags
+                        }
                         installed={installed}
+                        installSupported={Boolean(extension.install)}
                         onInstall={() => onInstallClick(extension)}
                         onUninstall={() => onUninstallClick(extension)}
+                        advancedContent={
+                          installed && getAdvancedContent
+                            ? getAdvancedContent(extension)
+                            : undefined
+                        }
+                        moreInfoContent={
+                          installed && getMoreInfoContent
+                            ? getMoreInfoContent(extension)
+                            : undefined
+                        }
                       />
                     </div>
                   </div>

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -166,71 +166,65 @@ export function ExtensionsBrowser({
   );
 
   return (
-    <div className="flex flex-col gap-3 rounded-md border p-3">
-      <div className="flex items-center gap-2">
-        <p className="text-sm font-medium">Browse Extensions</p>
-      </div>
-
-      <Command
-        shouldFilter={false}
-        className="border-border rounded-md border bg-transparent"
+    <Command
+      shouldFilter={false}
+      className="border-border rounded-md border bg-transparent"
+    >
+      <CommandInput
+        value={query}
+        onValueChange={setQuery}
+        placeholder="Search extensions..."
+      />
+      <CommandList
+        ref={parentRef}
+        className="rounded-none border-0"
+        style={{ height: listHeight }}
       >
-        <CommandInput
-          value={query}
-          onValueChange={setQuery}
-          placeholder="Search extensions..."
-        />
-        <CommandList
-          ref={parentRef}
-          className="rounded-none border-0"
-          style={{ height: listHeight }}
-        >
-          {filteredExtensions.length === 0 ? (
-            <CommandEmpty className="flex h-full items-center justify-center py-0 text-center">
-              No extensions match your search.
-            </CommandEmpty>
-          ) : (
-            <CommandGroup className="p-2">
-              <div
-                style={{
-                  height: `${virtualizer.getTotalSize()}px`,
-                  width: "100%",
-                  position: "relative",
-                }}
-              >
-                {virtualizer.getVirtualItems().map((virtualItem) => {
-                  const extension = filteredExtensions[virtualItem.index];
-                  const installed = isInstalled(extension);
+        {filteredExtensions.length === 0 ? (
+          <CommandEmpty className="flex h-full items-center justify-center py-0 text-center">
+            No extensions match your search.
+          </CommandEmpty>
+        ) : (
+          <CommandGroup className="p-2">
+            <div
+              style={{
+                height: `${virtualizer.getTotalSize()}px`,
+                width: "100%",
+                position: "relative",
+              }}
+            >
+              {virtualizer.getVirtualItems().map((virtualItem) => {
+                const extension = filteredExtensions[virtualItem.index];
+                const installed = isInstalled(extension);
 
-                  return (
-                    <div
-                      key={extension.id}
-                      data-index={virtualItem.index}
-                      ref={virtualizer.measureElement}
-                      style={{
-                        position: "absolute",
-                        top: 0,
-                        left: 0,
-                        width: "100%",
-                        transform: `translateY(${virtualItem.start}px)`,
-                      }}
-                    >
-                      <div className="py-1">
-                        <ExtensionRow
-                          extension={extension}
-                          installed={installed}
-                          onInstall={() => onInstallClick(extension)}
-                          onUninstall={() => onUninstallClick(extension)}
-                        />
-                      </div>
+                return (
+                  <div
+                    key={extension.id}
+                    data-index={virtualItem.index}
+                    ref={virtualizer.measureElement}
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      width: "100%",
+                      transform: `translateY(${virtualItem.start}px)`,
+                    }}
+                  >
+                    <div className="py-1">
+                      <ExtensionRow
+                        extension={extension}
+                        installed={installed}
+                        onInstall={() => onInstallClick(extension)}
+                        onUninstall={() => onUninstallClick(extension)}
+                      />
                     </div>
-                  );
-                })}
-              </div>
-            </CommandGroup>
-          )}
-        </CommandList>
-      </Command>
-    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
   );
 }

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -85,11 +85,11 @@ export function ExtensionsBrowser({
       />
       <CommandList
         ref={parentRef}
-        className="h-[60vh] max-h-[52rem] min-h-[26rem] rounded-none border-0"
+        className="max-h-[75svh] rounded-none border-0"
       >
         {filteredExtensions.length === 0 ? (
           <CommandEmpty className="h-full py-3">
-            <div className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
+            <div className="text-muted-foreground rounded-md p-8 text-center text-sm">
               {filter === "installed"
                 ? "No installed extensions match your search."
                 : "No extensions match your search."}

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -163,7 +163,10 @@ export function ExtensionsBrowser({
         <p className="text-sm font-medium">Extensions Registry</p>
       </div>
 
-      <Command shouldFilter={false}>
+      <Command
+        shouldFilter={false}
+        className="border-border rounded-md border bg-transparent"
+      >
         <CommandInput
           value={query}
           onValueChange={setQuery}
@@ -171,7 +174,7 @@ export function ExtensionsBrowser({
         />
         <CommandList
           ref={parentRef}
-          className="border-border rounded-md border"
+          className="rounded-none border-0"
           style={{ height: listHeight }}
         >
           {filteredExtensions.length === 0 ? (

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ExternalLinkIcon, SparklesIcon } from "lucide-react";
+import { ExternalLinkIcon, Trash2Icon } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
 import {
@@ -21,8 +21,9 @@ import { commandScore } from "@/lib/command-score";
 const ESTIMATED_EXTENSION_ITEM_HEIGHT = 148;
 
 interface ExtensionsBrowserProps {
-  installedRegistryNames: Set<string>;
+  isInstalled: (extension: McpRegistryExtension) => boolean;
   onInstallClick: (extension: McpRegistryExtension) => void;
+  onUninstallClick: (extension: McpRegistryExtension) => void;
 }
 
 function getInitials(name: string): string {
@@ -40,10 +41,12 @@ function ExtensionRow({
   extension,
   installed,
   onInstall,
+  onUninstall,
 }: {
   extension: McpRegistryExtension;
   installed: boolean;
   onInstall: () => void;
+  onUninstall: () => void;
 }) {
   return (
     <div className="flex w-full items-start gap-4 rounded-md border p-4">
@@ -61,6 +64,9 @@ function ExtensionRow({
             {extension.displayName}
           </p>
           <Badge variant="outline">v{extension.version}</Badge>
+          {!extension.publisher ? (
+            <Badge variant="secondary">Community</Badge>
+          ) : null}
         </div>
 
         <p className="text-muted-foreground line-clamp-2 text-xs">
@@ -70,9 +76,7 @@ function ExtensionRow({
         <div className="text-muted-foreground flex min-w-0 flex-wrap items-center gap-2 text-xs">
           {extension.publisher ? (
             <span className="truncate">by {extension.publisher}</span>
-          ) : (
-            <span>Community extension</span>
-          )}
+          ) : null}
           {(extension.categories.length > 0
             ? extension.categories
             : extension.tags
@@ -96,26 +100,30 @@ function ExtensionRow({
           </Button>
         ) : null}
 
-        <Button
-          size="sm"
-          variant={installed ? "outline" : "default"}
-          onClick={onInstall}
-          disabled={installed || !extension.install}
-        >
-          {installed
-            ? "Installed"
-            : extension.install
-              ? "Install"
-              : "Unsupported"}
-        </Button>
+        {installed ? (
+          <Button size="sm" variant="destructive" onClick={onUninstall}>
+            <Trash2Icon className="size-4" />
+            Uninstall
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="default"
+            onClick={onInstall}
+            disabled={!extension.install}
+          >
+            {extension.install ? "Install" : "Unsupported"}
+          </Button>
+        )}
       </div>
     </div>
   );
 }
 
 export function ExtensionsBrowser({
-  installedRegistryNames,
+  isInstalled,
   onInstallClick,
+  onUninstallClick,
 }: ExtensionsBrowserProps) {
   const [query, setQuery] = useState("");
   const parentRef = useRef<HTMLDivElement>(null);
@@ -160,8 +168,7 @@ export function ExtensionsBrowser({
   return (
     <div className="flex flex-col gap-3 rounded-md border p-3">
       <div className="flex items-center gap-2">
-        <SparklesIcon className="text-muted-foreground size-4" />
-        <p className="text-sm font-medium">Extensions Registry</p>
+        <p className="text-sm font-medium">Browse Extensions</p>
       </div>
 
       <Command
@@ -179,7 +186,9 @@ export function ExtensionsBrowser({
           style={{ height: listHeight }}
         >
           {filteredExtensions.length === 0 ? (
-            <CommandEmpty>No extensions match your search.</CommandEmpty>
+            <CommandEmpty className="flex h-full items-center justify-center py-0 text-center">
+              No extensions match your search.
+            </CommandEmpty>
           ) : (
             <CommandGroup className="p-2">
               <div
@@ -191,9 +200,7 @@ export function ExtensionsBrowser({
               >
                 {virtualizer.getVirtualItems().map((virtualItem) => {
                   const extension = filteredExtensions[virtualItem.index];
-                  const installed = installedRegistryNames.has(
-                    extension.registryName,
-                  );
+                  const installed = isInstalled(extension);
 
                   return (
                     <div
@@ -213,6 +220,7 @@ export function ExtensionsBrowser({
                           extension={extension}
                           installed={installed}
                           onInstall={() => onInstallClick(extension)}
+                          onUninstall={() => onUninstallClick(extension)}
                         />
                       </div>
                     </div>

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -25,7 +25,7 @@ interface ExtensionsBrowserProps {
   onInstallClick: (extension: McpRegistryExtension) => void;
   onUninstallClick: (extension: McpRegistryExtension) => void;
   getAdvancedContent?: (extension: McpRegistryExtension) => ReactNode;
-  getMoreInfoContent?: (extension: McpRegistryExtension) => ReactNode;
+  getMoreInfoJson?: (extension: McpRegistryExtension) => unknown;
 }
 
 export function ExtensionsBrowser({
@@ -34,7 +34,7 @@ export function ExtensionsBrowser({
   onInstallClick,
   onUninstallClick,
   getAdvancedContent,
-  getMoreInfoContent,
+  getMoreInfoJson,
 }: ExtensionsBrowserProps) {
   const [query, setQuery] = useState("");
   const parentRef = useRef<HTMLDivElement>(null);
@@ -142,9 +142,9 @@ export function ExtensionsBrowser({
                             ? getAdvancedContent(extension)
                             : undefined
                         }
-                        moreInfoContent={
-                          installed && getMoreInfoContent
-                            ? getMoreInfoContent(extension)
+                        moreInfoJson={
+                          installed && getMoreInfoJson
+                            ? getMoreInfoJson(extension)
                             : undefined
                         }
                       />

--- a/src/routes/settings/sections/mcp/extensions-browser.tsx
+++ b/src/routes/settings/sections/mcp/extensions-browser.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { SearchIcon, SparklesIcon } from "lucide-react";
+import { ExternalLinkIcon, SparklesIcon } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
 import {
@@ -9,9 +9,16 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandList,
+} from "@/components/ui/command";
+import { commandScore } from "@/lib/command-score";
 
-const EXTENSION_ITEM_HEIGHT = 106;
+const ESTIMATED_EXTENSION_ITEM_HEIGHT = 148;
 
 interface ExtensionsBrowserProps {
   installedRegistryNames: Set<string>;
@@ -39,8 +46,8 @@ function ExtensionRow({
   onInstall: () => void;
 }) {
   return (
-    <div className="flex h-full items-start justify-between gap-3 border-b px-3 py-3">
-      <Avatar className="mt-0.5" size="sm">
+    <div className="flex w-full items-start gap-4 rounded-md border p-4">
+      <Avatar size="sm">
         <AvatarImage
           src={extension.iconUrl}
           alt={`${extension.displayName} icon`}
@@ -48,37 +55,59 @@ function ExtensionRow({
         <AvatarFallback>{getInitials(extension.displayName)}</AvatarFallback>
       </Avatar>
 
-      <div className="min-w-0 flex-1">
-        <div className="mb-1 flex items-center gap-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           <p className="truncate text-sm font-medium">
             {extension.displayName}
           </p>
           <Badge variant="outline">v{extension.version}</Badge>
-          {extension.officialStatus === "active" ? (
-            <Badge className="bg-emerald-600 hover:bg-emerald-600">
-              Official
-            </Badge>
-          ) : null}
         </div>
+
         <p className="text-muted-foreground line-clamp-2 text-xs">
           {extension.description}
         </p>
-        <p className="text-muted-foreground mt-1 truncate text-xs">
-          {extension.registryName}
-        </p>
+
+        <div className="text-muted-foreground flex min-w-0 flex-wrap items-center gap-2 text-xs">
+          <span className="truncate">{extension.registryName}</span>
+          {extension.publisher ? (
+            <span className="truncate">by {extension.publisher}</span>
+          ) : null}
+          {(extension.categories.length > 0
+            ? extension.categories
+            : extension.tags
+          )
+            .slice(0, 2)
+            .map((tag) => (
+              <Badge key={`${extension.id}-${tag}`} variant="outline">
+                {tag}
+              </Badge>
+            ))}
+        </div>
       </div>
-      <Button
-        size="sm"
-        variant={installed ? "outline" : "default"}
-        onClick={onInstall}
-        disabled={installed || !extension.install}
-      >
-        {installed
-          ? "Installed"
-          : extension.install
-            ? "Install"
-            : "Unsupported"}
-      </Button>
+
+      <div className="flex shrink-0 items-center gap-2">
+        {extension.websiteUrl ? (
+          <Button variant="outline" size="sm" asChild>
+            <a href={extension.websiteUrl} target="_blank" rel="noreferrer">
+              <ExternalLinkIcon className="size-4" />
+              Website
+            </a>
+          </Button>
+        ) : null}
+
+        <Button
+          size="sm"
+          variant={installed ? "outline" : "default"}
+          onClick={onInstall}
+          disabled={installed || !extension.install}
+        >
+          {installed
+            ? "Installed"
+            : extension.install
+              ? "Install"
+              : "Unsupported"}
+        </Button>
+      </div>
     </div>
   );
 }
@@ -93,25 +122,37 @@ export function ExtensionsBrowser({
   const extensions = useMemo(() => getMcpRegistryExtensions(), []);
 
   const filteredExtensions = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
+    const normalizedQuery = query.trim();
     if (!normalizedQuery) {
       return extensions;
     }
-    return extensions.filter((extension) =>
-      extension.searchText.includes(normalizedQuery),
-    );
+
+    return extensions
+      .map((extension) => ({
+        extension,
+        score: commandScore(extension.displayName, normalizedQuery, [
+          extension.registryName,
+          extension.searchText,
+        ]),
+      }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map(({ extension }) => extension);
   }, [extensions, query]);
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
     count: filteredExtensions.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => EXTENSION_ITEM_HEIGHT,
+    estimateSize: () => ESTIMATED_EXTENSION_ITEM_HEIGHT,
+    getItemKey: (index) => filteredExtensions[index]?.id ?? index,
+    measureElement: (element) => element.getBoundingClientRect().height,
     overscan: 6,
   });
 
+  const totalSize = virtualizer.getTotalSize();
   const listHeight = Math.min(
-    filteredExtensions.length * EXTENSION_ITEM_HEIGHT,
+    totalSize || ESTIMATED_EXTENSION_ITEM_HEIGHT,
     420,
   );
 
@@ -122,62 +163,62 @@ export function ExtensionsBrowser({
         <p className="text-sm font-medium">Extensions Registry</p>
       </div>
 
-      <div className="relative">
-        <SearchIcon className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-        <Input
+      <Command shouldFilter={false}>
+        <CommandInput
           value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search extensions"
-          className="pl-9"
+          onValueChange={setQuery}
+          placeholder="Search extensions..."
         />
-      </div>
-
-      {filteredExtensions.length > 0 ? (
-        <div
+        <CommandList
           ref={parentRef}
-          className="border-border overflow-y-auto rounded-md border"
-          style={{ height: listHeight || EXTENSION_ITEM_HEIGHT }}
+          className="border-border rounded-md border"
+          style={{ height: listHeight }}
         >
-          <div
-            style={{
-              height: `${virtualizer.getTotalSize()}px`,
-              width: "100%",
-              position: "relative",
-            }}
-          >
-            {virtualizer.getVirtualItems().map((virtualItem) => {
-              const extension = filteredExtensions[virtualItem.index];
-              const installed = installedRegistryNames.has(
-                extension.registryName,
-              );
+          {filteredExtensions.length === 0 ? (
+            <CommandEmpty>No extensions match your search.</CommandEmpty>
+          ) : (
+            <CommandGroup className="p-2">
+              <div
+                style={{
+                  height: `${virtualizer.getTotalSize()}px`,
+                  width: "100%",
+                  position: "relative",
+                }}
+              >
+                {virtualizer.getVirtualItems().map((virtualItem) => {
+                  const extension = filteredExtensions[virtualItem.index];
+                  const installed = installedRegistryNames.has(
+                    extension.registryName,
+                  );
 
-              return (
-                <div
-                  key={extension.id}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    height: `${virtualItem.size}px`,
-                    transform: `translateY(${virtualItem.start}px)`,
-                  }}
-                >
-                  <ExtensionRow
-                    extension={extension}
-                    installed={installed}
-                    onInstall={() => onInstallClick(extension)}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      ) : (
-        <div className="text-muted-foreground flex h-20 items-center justify-center rounded-md border border-dashed text-sm">
-          No extensions match your search.
-        </div>
-      )}
+                  return (
+                    <div
+                      key={extension.id}
+                      data-index={virtualItem.index}
+                      ref={virtualizer.measureElement}
+                      style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        width: "100%",
+                        transform: `translateY(${virtualItem.start}px)`,
+                      }}
+                    >
+                      <div className="py-1">
+                        <ExtensionRow
+                          extension={extension}
+                          installed={installed}
+                          onInstall={() => onInstallClick(extension)}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
     </div>
   );
 }

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -26,6 +26,23 @@ import { DeleteServerDialog } from "./delete-server-dialog";
 import { ExtensionsBrowser } from "./extensions-browser";
 import { InstallExtensionDialog } from "./install-extension-dialog";
 import { ServerListItem } from "./server-list-item";
+import { UninstallExtensionDialog } from "./uninstall-extension-dialog";
+
+function toRegistryIdFragment(registryName: string): string {
+  return registryName.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function isServerInstalledFromExtension(
+  server: McpServerConfig,
+  extension: McpRegistryExtension,
+): boolean {
+  const registryIdFragment = toRegistryIdFragment(extension.registryName);
+  return (
+    server.id.includes(`registry-${registryIdFragment}`) ||
+    server.name === extension.displayName ||
+    server.name === extension.registryName
+  );
+}
 
 export default function McpSection() {
   const [mcpServers, setMcpServers] = useAtom(mcpServersAtom);
@@ -59,6 +76,9 @@ export default function McpSection() {
   const [selectedExtension, setSelectedExtension] =
     useState<McpRegistryExtension | null>(null);
   const [showInstallDialog, setShowInstallDialog] = useState(false);
+  const [extensionToUninstall, setExtensionToUninstall] =
+    useState<McpRegistryExtension | null>(null);
+  const [showUninstallDialog, setShowUninstallDialog] = useState(false);
 
   const handleDeleteClick = (index: number) => {
     setServerToDelete(index);
@@ -115,8 +135,12 @@ export default function McpSection() {
   };
 
   const handleInstallExtension = (installed: McpRegistryInstallResult) => {
+    const registryName = selectedExtension?.registryName;
+    const idPrefix = registryName
+      ? `server-${uniqueId}-registry-${toRegistryIdFragment(registryName)}`
+      : `server-${uniqueId}`;
     const baseServer = {
-      id: `server-${uniqueId}-${crypto.randomUUID()}`,
+      id: `${idPrefix}-${crypto.randomUUID()}`,
       name: installed.name,
       enabled: true,
       timeoutMs: installed.timeoutSec * 1000,
@@ -142,6 +166,44 @@ export default function McpSection() {
     toast.success(`${installed.name} installed`);
   };
 
+  const handleExtensionUninstallClick = (extension: McpRegistryExtension) => {
+    setExtensionToUninstall(extension);
+    setShowUninstallDialog(true);
+  };
+
+  const handleConfirmExtensionUninstall = () => {
+    if (!extensionToUninstall) {
+      return;
+    }
+
+    let removedServerName: string | null = null;
+
+    setMcpServers((prev) => {
+      const targetIndex = prev.findIndex((server) =>
+        isServerInstalledFromExtension(server, extensionToUninstall),
+      );
+
+      if (targetIndex === -1) {
+        return prev;
+      }
+
+      removedServerName =
+        prev[targetIndex]?.name ?? extensionToUninstall.displayName;
+      return prev.filter((_, index) => index !== targetIndex);
+    });
+
+    toast.success(
+      `${removedServerName ?? extensionToUninstall.displayName} removed`,
+    );
+    setExtensionToUninstall(null);
+    setShowUninstallDialog(false);
+  };
+
+  const handleCancelExtensionUninstall = () => {
+    setExtensionToUninstall(null);
+    setShowUninstallDialog(false);
+  };
+
   const handleExtensionInstallClick = (extension: McpRegistryExtension) => {
     if (!extension.install) {
       return;
@@ -151,9 +213,11 @@ export default function McpSection() {
     setShowInstallDialog(true);
   };
 
-  const installedRegistryNames = new Set(
-    mcpServers.map((server) => server.name),
-  );
+  const isExtensionInstalled = (extension: McpRegistryExtension): boolean => {
+    return mcpServers.some((server) =>
+      isServerInstalledFromExtension(server, extension),
+    );
+  };
 
   return (
     <Card>
@@ -234,8 +298,9 @@ export default function McpSection() {
 
           <TabsContent value="extensions" className="mt-3">
             <ExtensionsBrowser
-              installedRegistryNames={installedRegistryNames}
+              isInstalled={isExtensionInstalled}
               onInstallClick={handleExtensionInstallClick}
+              onUninstallClick={handleExtensionUninstallClick}
             />
           </TabsContent>
         </Tabs>
@@ -259,6 +324,14 @@ export default function McpSection() {
         open={showInstallDialog}
         onOpenChange={setShowInstallDialog}
         onInstall={handleInstallExtension}
+      />
+
+      <UninstallExtensionDialog
+        extension={extensionToUninstall}
+        open={showUninstallDialog}
+        onOpenChange={setShowUninstallDialog}
+        onConfirm={handleConfirmExtensionUninstall}
+        onCancel={handleCancelExtensionUninstall}
       />
     </Card>
   );

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -1,30 +1,24 @@
 import { useAtom } from "jotai";
-import { RotateCcwIcon } from "lucide-react";
-import { useId, useState } from "react";
+import { PlusIcon } from "lucide-react";
+import { useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import {
+  getMcpRegistryExtensions,
   type McpRegistryExtension,
   type McpRegistryInstallResult,
 } from "@/assets/mcp-registry/mcp-registry";
-import { NoMcpServers } from "@/components/a1/empty-states/no-mcp-servers";
-import { Accordion } from "@/components/ui/accordion";
+import type { MCPRegistryEntry } from "@/assets/mcp-registry/types";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  mcpParallelLoadLimitAtom,
-  mcpServersAtom,
-} from "@/lib/jotai/settings-atoms";
-import { resetSetting } from "@/lib/settings/reset-settings";
-import { DEFAULT_SETTINGS, type McpServerConfig } from "@/lib/settings/types";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { mcpServersAtom } from "@/lib/jotai/settings-atoms";
+import { type McpServerConfig } from "@/lib/settings/types";
 
 import { AddServerDialog } from "./add-server-dialog";
-import { DeleteServerDialog } from "./delete-server-dialog";
+import { ExtensionAdvancedDetails } from "./extension-advanced-details";
+import { ExtensionListRow } from "./extension-list-row";
 import { ExtensionsBrowser } from "./extensions-browser";
 import { InstallExtensionDialog } from "./install-extension-dialog";
-import { ServerListItem } from "./server-list-item";
 import { UninstallExtensionDialog } from "./uninstall-extension-dialog";
 
 function toRegistryIdFragment(registryName: string): string {
@@ -42,35 +36,164 @@ function isServerInstalledFromExtension(
   );
 }
 
+function isServerFromRegistry(server: McpServerConfig): boolean {
+  return server.id.includes("@");
+}
+
+function toCustomExtension(server: McpServerConfig): McpRegistryExtension {
+  return {
+    id: server.id,
+    registryName: server.name,
+    displayName: server.name || "Custom Extension",
+    description: server.type === "stdio" ? server.command : server.url,
+    version: "custom",
+    categories: ["custom"],
+    tags: [server.type],
+    keywords: [],
+    packageCount: 0,
+    requiredFieldCount: 0,
+    transportTypes: [server.type],
+    searchText: "custom",
+    registryEntry: {
+      server: {
+        $schema: "",
+        name: server.name || "custom",
+        description: "Custom extension",
+        version: "custom",
+      },
+      _meta: {
+        "io.modelcontextprotocol.registry/official": {
+          status: "custom",
+          publishedAt: new Date(),
+          updatedAt: new Date(),
+          isLatest: true,
+        },
+      },
+    },
+  };
+}
+
+function getFieldValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function RegistryKeyValueList({
+  title,
+  data,
+}: {
+  title: string;
+  data: Record<string, unknown>;
+}) {
+  const entries = Object.entries(data);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <p className="text-sm font-medium">{title}</p>
+      {entries.length === 0 ? (
+        <p className="text-muted-foreground text-xs">No data available.</p>
+      ) : (
+        <div className="grid gap-1">
+          {entries.map(([key, value]) => (
+            <div
+              key={key}
+              className="flex flex-col gap-1 sm:flex-row sm:items-start sm:gap-2"
+            >
+              <span className="text-muted-foreground min-w-44 text-xs font-medium break-all">
+                {key}
+              </span>
+              <span className="text-xs break-all">{getFieldValue(value)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RegistryArrayList({
+  title,
+  items,
+}: {
+  title: string;
+  items: unknown[];
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-md border p-3">
+      <p className="text-sm font-medium">{title}</p>
+      {items.length === 0 ? (
+        <p className="text-muted-foreground text-xs">No data available.</p>
+      ) : (
+        <ul className="list-disc pl-5 text-xs">
+          {items.map((item, index) => (
+            <li key={`${title}-${index}`} className="break-all">
+              {getFieldValue(item)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function RegistryValue({ title, value }: { title: string; value: unknown }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-md border p-3">
+      <p className="text-sm font-medium">{title}</p>
+      <p className="text-xs break-all">{getFieldValue(value)}</p>
+    </div>
+  );
+}
+
+function RegistryDataViewer({ entry }: { entry: MCPRegistryEntry }) {
+  const rows = useMemo(() => {
+    const data: Array<{ key: string; value: unknown }> = [];
+    for (const [key, value] of Object.entries(entry.server)) {
+      data.push({ key: `server.${key}`, value });
+    }
+    for (const [key, value] of Object.entries(entry._meta)) {
+      data.push({ key: `_meta.${key}`, value });
+    }
+    return data;
+  }, [entry]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {rows.map(({ key, value }) => {
+        if (Array.isArray(value)) {
+          return <RegistryArrayList key={key} title={key} items={value} />;
+        }
+
+        if (value && typeof value === "object") {
+          return (
+            <RegistryKeyValueList
+              key={key}
+              title={key}
+              data={value as Record<string, unknown>}
+            />
+          );
+        }
+
+        return <RegistryValue key={key} title={key} value={value} />;
+      })}
+    </div>
+  );
+}
+
 export default function McpSection() {
   const [mcpServers, setMcpServers] = useAtom(mcpServersAtom);
-  const [parallelLoadLimit, setParallelLoadLimit] = useAtom(
-    mcpParallelLoadLimitAtom,
-  );
-
   const uniqueId = useId();
 
-  const isParallelLoadLimitDefault =
-    parallelLoadLimit === DEFAULT_SETTINGS.MCP_PARALLEL_LOAD_LIMIT;
-
-  const handleResetParallelLoadLimit = () => {
-    resetSetting("MCP_PARALLEL_LOAD_LIMIT");
-  };
-
-  const updateMcpServer = (
-    index: number,
-    updates: Partial<McpServerConfig>,
-  ) => {
-    setMcpServers((prev) =>
-      prev.map((server, i) =>
-        i === index ? ({ ...server, ...updates } as McpServerConfig) : server,
-      ),
-    );
-  };
-
   const [showAddDialog, setShowAddDialog] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [serverToDelete, setServerToDelete] = useState<number | null>(null);
   const [selectedExtension, setSelectedExtension] =
     useState<McpRegistryExtension | null>(null);
   const [showInstallDialog, setShowInstallDialog] = useState(false);
@@ -78,22 +201,32 @@ export default function McpSection() {
     useState<McpRegistryExtension | null>(null);
   const [showUninstallDialog, setShowUninstallDialog] = useState(false);
 
-  const handleDeleteClick = (index: number) => {
-    setServerToDelete(index);
-    setShowDeleteDialog(true);
-  };
+  const defaultExtensions = useMemo(() => getMcpRegistryExtensions(), []);
 
-  const confirmDelete = () => {
-    if (serverToDelete !== null) {
-      setMcpServers((prev) => prev.filter((_, i) => i !== serverToDelete));
+  const extensionByServerId = useMemo(() => {
+    const map = new Map<string, McpRegistryExtension>();
+    for (const extension of defaultExtensions) {
+      map.set(extension.id, extension);
     }
-    setServerToDelete(null);
-    setShowDeleteDialog(false);
-  };
+    return map;
+  }, [defaultExtensions]);
 
-  const cancelDelete = () => {
-    setServerToDelete(null);
-    setShowDeleteDialog(false);
+  const customServers = useMemo(
+    () => mcpServers.filter((server) => !isServerFromRegistry(server)),
+    [mcpServers],
+  );
+
+  const updateMcpServerById = (
+    serverId: string,
+    updates: Partial<McpServerConfig>,
+  ) => {
+    setMcpServers((prev) =>
+      prev.map((server) =>
+        server.id === serverId
+          ? ({ ...server, ...updates } as McpServerConfig)
+          : server,
+      ),
+    );
   };
 
   const handleAddServer = (serverData: {
@@ -214,104 +347,132 @@ export default function McpSection() {
     );
   };
 
+  const getExtensionServer = (extension: McpRegistryExtension) => {
+    return mcpServers.find((server) =>
+      isServerInstalledFromExtension(server, extension),
+    );
+  };
+
+  // TODO: Reintroduce MCP parallel load limit in a dedicated runtime/performance settings section.
+
   return (
-    <div className="flex flex-col gap-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>Browse Extensions</CardTitle>
-        </CardHeader>
-        <CardContent>
+    <div className="flex flex-col gap-4">
+      <h3 className="text-base font-semibold">Extensions</h3>
+
+      <Tabs defaultValue="all" className="gap-4">
+        <TabsList>
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="installed">Installed</TabsTrigger>
+          <TabsTrigger value="custom">Custom</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="all">
           <ExtensionsBrowser
+            filter="all"
             isInstalled={isExtensionInstalled}
             onInstallClick={handleExtensionInstallClick}
             onUninstallClick={handleExtensionUninstallClick}
-          />
-        </CardContent>
-      </Card>
+            getAdvancedContent={(extension) => {
+              const server = getExtensionServer(extension);
+              if (!server) {
+                return null;
+              }
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Advanced</CardTitle>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
-            <div className="flex flex-1 flex-col items-start">
-              <Label
-                htmlFor="parallel-load-limit"
-                className="text-sm font-medium"
-              >
-                Parallel Load Limit
-              </Label>
-              <p className="text-muted-foreground mt-1 text-sm">
-                Maximum number of MCP servers to load concurrently.
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <Input
-                id="parallel-load-limit"
-                type="number"
-                min="1"
-                max="20"
-                value={parallelLoadLimit}
-                onChange={(e) =>
-                  setParallelLoadLimit(parseInt(e.target.value) || 8)
-                }
-                className="w-20"
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleResetParallelLoadLimit}
-                disabled={isParallelLoadLimitDefault}
-                aria-label="Reset to default"
-              >
-                <RotateCcwIcon className="size-4" />
-              </Button>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center justify-between">
-              <Label className="text-sm font-medium">Configured Servers</Label>
-              <Button onClick={() => setShowAddDialog(true)} size="sm">
-                Add Server
-              </Button>
-            </div>
-
-            {mcpServers.length === 0 ? (
-              <NoMcpServers />
-            ) : (
-              <Accordion
-                type="single"
-                collapsible
-                className="border-border w-full rounded-md border"
-              >
-                {mcpServers.map((server, index) => (
-                  <ServerListItem
-                    key={server.id}
-                    server={server}
-                    index={index}
-                    onUpdate={updateMcpServer}
-                    onDelete={handleDeleteClick}
-                  />
-                ))}
-              </Accordion>
+              return (
+                <ExtensionAdvancedDetails
+                  server={server}
+                  onUpdate={(updates) =>
+                    updateMcpServerById(server.id, updates)
+                  }
+                />
+              );
+            }}
+            getMoreInfoContent={(extension) => (
+              <RegistryDataViewer entry={extension.registryEntry} />
             )}
+          />
+        </TabsContent>
+
+        <TabsContent value="installed">
+          <ExtensionsBrowser
+            filter="installed"
+            isInstalled={isExtensionInstalled}
+            onInstallClick={handleExtensionInstallClick}
+            onUninstallClick={handleExtensionUninstallClick}
+            getAdvancedContent={(extension) => {
+              const server = getExtensionServer(extension);
+              if (!server) {
+                return null;
+              }
+
+              return (
+                <ExtensionAdvancedDetails
+                  server={server}
+                  onUpdate={(updates) =>
+                    updateMcpServerById(server.id, updates)
+                  }
+                />
+              );
+            }}
+            getMoreInfoContent={(extension) => (
+              <RegistryDataViewer entry={extension.registryEntry} />
+            )}
+          />
+        </TabsContent>
+
+        <TabsContent value="custom" className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h4 className="text-sm font-medium">Custom Extensions</h4>
+            <Button size="sm" onClick={() => setShowAddDialog(true)}>
+              <PlusIcon className="size-4" />
+              Add Custom
+            </Button>
           </div>
-        </CardContent>
-      </Card>
+
+          {customServers.length === 0 ? (
+            <div className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
+              No custom extensions yet. Use Add Custom to create one.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {customServers.map((server) => {
+                const linkedExtension = extensionByServerId.get(server.id);
+                const uninstallTarget =
+                  linkedExtension ?? toCustomExtension(server);
+
+                return (
+                  <ExtensionListRow
+                    key={server.id}
+                    title={server.name || "Custom Extension"}
+                    description={
+                      server.type === "stdio" ? server.command : server.url
+                    }
+                    version="custom"
+                    badges={["custom", server.type]}
+                    installed
+                    onUninstall={() =>
+                      handleExtensionUninstallClick(uninstallTarget)
+                    }
+                    advancedContent={
+                      <ExtensionAdvancedDetails
+                        server={server}
+                        onUpdate={(updates) =>
+                          updateMcpServerById(server.id, updates)
+                        }
+                      />
+                    }
+                  />
+                );
+              })}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
 
       <AddServerDialog
         open={showAddDialog}
         onOpenChange={setShowAddDialog}
         onAddServer={handleAddServer}
-      />
-
-      <DeleteServerDialog
-        open={showDeleteDialog}
-        onOpenChange={setShowDeleteDialog}
-        onConfirm={confirmDelete}
-        onCancel={cancelDelete}
       />
 
       <InstallExtensionDialog

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -9,6 +9,7 @@ import {
   type McpRegistryInstallResult,
 } from "@/assets/mcp-registry/mcp-registry";
 import type { MCPRegistryEntry } from "@/assets/mcp-registry/types";
+import { NoCustomExtensions } from "@/components/a1/empty-states/no-custom-extensions";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { mcpServersAtom } from "@/lib/jotai/settings-atoms";
@@ -430,9 +431,7 @@ export default function McpSection() {
           </div>
 
           {customServers.length === 0 ? (
-            <div className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
-              No custom extensions yet. Use Add Custom to create one.
-            </div>
+            <NoCustomExtensions />
           ) : (
             <div className="flex flex-col gap-2">
               {customServers.map((server) => {

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -11,6 +11,7 @@ import {
 import type { MCPRegistryEntry } from "@/assets/mcp-registry/types";
 import { NoCustomExtensions } from "@/components/a1/empty-states/no-custom-extensions";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { mcpServersAtom } from "@/lib/jotai/settings-atoms";
 import { type McpServerConfig } from "@/lib/settings/types";
@@ -357,137 +358,140 @@ export default function McpSection() {
   // TODO: Reintroduce MCP parallel load limit in a dedicated runtime/performance settings section.
 
   return (
-    <div className="flex flex-col gap-4">
-      <h3 className="text-base font-semibold">Extensions</h3>
+    <Card>
+      <CardHeader>
+        <h3 className="text-base leading-none font-semibold">Extensions</h3>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <Tabs defaultValue="all" className="gap-4">
+          <TabsList>
+            <TabsTrigger value="all">All</TabsTrigger>
+            <TabsTrigger value="installed">Installed</TabsTrigger>
+            <TabsTrigger value="custom">Custom</TabsTrigger>
+          </TabsList>
 
-      <Tabs defaultValue="all" className="gap-4">
-        <TabsList>
-          <TabsTrigger value="all">All</TabsTrigger>
-          <TabsTrigger value="installed">Installed</TabsTrigger>
-          <TabsTrigger value="custom">Custom</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="all">
-          <ExtensionsBrowser
-            filter="all"
-            isInstalled={isExtensionInstalled}
-            onInstallClick={handleExtensionInstallClick}
-            onUninstallClick={handleExtensionUninstallClick}
-            getAdvancedContent={(extension) => {
-              const server = getExtensionServer(extension);
-              if (!server) {
-                return null;
-              }
-
-              return (
-                <ExtensionAdvancedDetails
-                  server={server}
-                  onUpdate={(updates) =>
-                    updateMcpServerById(server.id, updates)
-                  }
-                />
-              );
-            }}
-            getMoreInfoContent={(extension) => (
-              <RegistryDataViewer entry={extension.registryEntry} />
-            )}
-          />
-        </TabsContent>
-
-        <TabsContent value="installed">
-          <ExtensionsBrowser
-            filter="installed"
-            isInstalled={isExtensionInstalled}
-            onInstallClick={handleExtensionInstallClick}
-            onUninstallClick={handleExtensionUninstallClick}
-            getAdvancedContent={(extension) => {
-              const server = getExtensionServer(extension);
-              if (!server) {
-                return null;
-              }
-
-              return (
-                <ExtensionAdvancedDetails
-                  server={server}
-                  onUpdate={(updates) =>
-                    updateMcpServerById(server.id, updates)
-                  }
-                />
-              );
-            }}
-            getMoreInfoContent={(extension) => (
-              <RegistryDataViewer entry={extension.registryEntry} />
-            )}
-          />
-        </TabsContent>
-
-        <TabsContent value="custom" className="space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h4 className="text-sm font-medium">Custom Extensions</h4>
-            <Button size="sm" onClick={() => setShowAddDialog(true)}>
-              <PlusIcon className="size-4" />
-              Add Custom
-            </Button>
-          </div>
-
-          {customServers.length === 0 ? (
-            <NoCustomExtensions />
-          ) : (
-            <div className="flex flex-col gap-2">
-              {customServers.map((server) => {
-                const linkedExtension = extensionByServerId.get(server.id);
-                const uninstallTarget =
-                  linkedExtension ?? toCustomExtension(server);
+          <TabsContent value="all">
+            <ExtensionsBrowser
+              filter="all"
+              isInstalled={isExtensionInstalled}
+              onInstallClick={handleExtensionInstallClick}
+              onUninstallClick={handleExtensionUninstallClick}
+              getAdvancedContent={(extension) => {
+                const server = getExtensionServer(extension);
+                if (!server) {
+                  return null;
+                }
 
                 return (
-                  <ExtensionListRow
-                    key={server.id}
-                    title={server.name || "Custom Extension"}
-                    description={
-                      server.type === "stdio" ? server.command : server.url
-                    }
-                    version="custom"
-                    badges={["custom", server.type]}
-                    installed
-                    onUninstall={() =>
-                      handleExtensionUninstallClick(uninstallTarget)
-                    }
-                    advancedContent={
-                      <ExtensionAdvancedDetails
-                        server={server}
-                        onUpdate={(updates) =>
-                          updateMcpServerById(server.id, updates)
-                        }
-                      />
+                  <ExtensionAdvancedDetails
+                    server={server}
+                    onUpdate={(updates) =>
+                      updateMcpServerById(server.id, updates)
                     }
                   />
                 );
-              })}
+              }}
+              getMoreInfoContent={(extension) => (
+                <RegistryDataViewer entry={extension.registryEntry} />
+              )}
+            />
+          </TabsContent>
+
+          <TabsContent value="installed">
+            <ExtensionsBrowser
+              filter="installed"
+              isInstalled={isExtensionInstalled}
+              onInstallClick={handleExtensionInstallClick}
+              onUninstallClick={handleExtensionUninstallClick}
+              getAdvancedContent={(extension) => {
+                const server = getExtensionServer(extension);
+                if (!server) {
+                  return null;
+                }
+
+                return (
+                  <ExtensionAdvancedDetails
+                    server={server}
+                    onUpdate={(updates) =>
+                      updateMcpServerById(server.id, updates)
+                    }
+                  />
+                );
+              }}
+              getMoreInfoContent={(extension) => (
+                <RegistryDataViewer entry={extension.registryEntry} />
+              )}
+            />
+          </TabsContent>
+
+          <TabsContent value="custom" className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h4 className="text-sm font-medium">Custom Extensions</h4>
+              <Button size="sm" onClick={() => setShowAddDialog(true)}>
+                <PlusIcon className="size-4" />
+                Add Custom
+              </Button>
             </div>
-          )}
-        </TabsContent>
-      </Tabs>
 
-      <AddServerDialog
-        open={showAddDialog}
-        onOpenChange={setShowAddDialog}
-        onAddServer={handleAddServer}
-      />
+            {customServers.length === 0 ? (
+              <NoCustomExtensions />
+            ) : (
+              <div className="flex flex-col gap-2">
+                {customServers.map((server) => {
+                  const linkedExtension = extensionByServerId.get(server.id);
+                  const uninstallTarget =
+                    linkedExtension ?? toCustomExtension(server);
 
-      <InstallExtensionDialog
-        extension={selectedExtension}
-        open={showInstallDialog}
-        onOpenChange={setShowInstallDialog}
-        onInstall={handleInstallExtension}
-      />
+                  return (
+                    <ExtensionListRow
+                      key={server.id}
+                      title={server.name || "Custom Extension"}
+                      description={
+                        server.type === "stdio" ? server.command : server.url
+                      }
+                      version="custom"
+                      badges={["custom", server.type]}
+                      installed
+                      onUninstall={() =>
+                        handleExtensionUninstallClick(uninstallTarget)
+                      }
+                      advancedContent={
+                        <ExtensionAdvancedDetails
+                          server={server}
+                          onUpdate={(updates) =>
+                            updateMcpServerById(server.id, updates)
+                          }
+                        />
+                      }
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
 
-      <UninstallExtensionDialog
-        extension={extensionToUninstall}
-        open={showUninstallDialog}
-        onOpenChange={setShowUninstallDialog}
-        onConfirm={handleConfirmExtensionUninstall}
-        onCancel={handleCancelExtensionUninstall}
-      />
-    </div>
+        <AddServerDialog
+          open={showAddDialog}
+          onOpenChange={setShowAddDialog}
+          onAddServer={handleAddServer}
+        />
+
+        <InstallExtensionDialog
+          extension={selectedExtension}
+          open={showInstallDialog}
+          onOpenChange={setShowInstallDialog}
+          onInstall={handleInstallExtension}
+        />
+
+        <UninstallExtensionDialog
+          extension={extensionToUninstall}
+          open={showUninstallDialog}
+          onOpenChange={setShowUninstallDialog}
+          onConfirm={handleConfirmExtensionUninstall}
+          onCancel={handleCancelExtensionUninstall}
+        />
+      </CardContent>
+    </Card>
   );
 }

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -38,9 +38,8 @@ function isServerInstalledFromExtension(
 ): boolean {
   const registryIdFragment = toRegistryIdFragment(extension.registryName);
   return (
-    server.id.includes(`registry-${registryIdFragment}`) ||
-    server.name === extension.displayName ||
-    server.name === extension.registryName
+    server.id === extension.id ||
+    server.id.includes(`registry-${registryIdFragment}`)
   );
 }
 
@@ -135,12 +134,9 @@ export default function McpSection() {
   };
 
   const handleInstallExtension = (installed: McpRegistryInstallResult) => {
-    const registryName = selectedExtension?.registryName;
-    const idPrefix = registryName
-      ? `server-${uniqueId}-registry-${toRegistryIdFragment(registryName)}`
-      : `server-${uniqueId}`;
+    const extensionId = selectedExtension?.id;
     const baseServer = {
-      id: `${idPrefix}-${crypto.randomUUID()}`,
+      id: extensionId ?? `server-${uniqueId}-${crypto.randomUUID()}`,
       name: installed.name,
       enabled: true,
       timeoutMs: installed.timeoutSec * 1000,

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -8,7 +8,6 @@ import {
   type McpRegistryExtension,
   type McpRegistryInstallResult,
 } from "@/assets/mcp-registry/mcp-registry";
-import type { MCPRegistryEntry } from "@/assets/mcp-registry/types";
 import { NoCustomExtensions } from "@/components/a1/empty-states/no-custom-extensions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -73,122 +72,6 @@ function toCustomExtension(server: McpServerConfig): McpRegistryExtension {
       },
     },
   };
-}
-
-function getFieldValue(value: unknown): string {
-  if (value === null || value === undefined) {
-    return "-";
-  }
-  if (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return String(value);
-  }
-  return JSON.stringify(value);
-}
-
-function RegistryKeyValueList({
-  title,
-  data,
-}: {
-  title: string;
-  data: Record<string, unknown>;
-}) {
-  const entries = Object.entries(data);
-
-  return (
-    <div className="flex flex-col gap-2 rounded-md border p-3">
-      <p className="text-sm font-medium">{title}</p>
-      {entries.length === 0 ? (
-        <p className="text-muted-foreground text-xs">No data available.</p>
-      ) : (
-        <div className="grid gap-1">
-          {entries.map(([key, value]) => (
-            <div
-              key={key}
-              className="flex flex-col gap-1 sm:flex-row sm:items-start sm:gap-2"
-            >
-              <span className="text-muted-foreground min-w-44 text-xs font-medium break-all">
-                {key}
-              </span>
-              <span className="text-xs break-all">{getFieldValue(value)}</span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function RegistryArrayList({
-  title,
-  items,
-}: {
-  title: string;
-  items: unknown[];
-}) {
-  return (
-    <div className="flex flex-col gap-2 rounded-md border p-3">
-      <p className="text-sm font-medium">{title}</p>
-      {items.length === 0 ? (
-        <p className="text-muted-foreground text-xs">No data available.</p>
-      ) : (
-        <ul className="list-disc pl-5 text-xs">
-          {items.map((item, index) => (
-            <li key={`${title}-${index}`} className="break-all">
-              {getFieldValue(item)}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-function RegistryValue({ title, value }: { title: string; value: unknown }) {
-  return (
-    <div className="flex flex-col gap-1 rounded-md border p-3">
-      <p className="text-sm font-medium">{title}</p>
-      <p className="text-xs break-all">{getFieldValue(value)}</p>
-    </div>
-  );
-}
-
-function RegistryDataViewer({ entry }: { entry: MCPRegistryEntry }) {
-  const rows = useMemo(() => {
-    const data: Array<{ key: string; value: unknown }> = [];
-    for (const [key, value] of Object.entries(entry.server)) {
-      data.push({ key: `server.${key}`, value });
-    }
-    for (const [key, value] of Object.entries(entry._meta)) {
-      data.push({ key: `_meta.${key}`, value });
-    }
-    return data;
-  }, [entry]);
-
-  return (
-    <div className="flex flex-col gap-3">
-      {rows.map(({ key, value }) => {
-        if (Array.isArray(value)) {
-          return <RegistryArrayList key={key} title={key} items={value} />;
-        }
-
-        if (value && typeof value === "object") {
-          return (
-            <RegistryKeyValueList
-              key={key}
-              title={key}
-              data={value as Record<string, unknown>}
-            />
-          );
-        }
-
-        return <RegistryValue key={key} title={key} value={value} />;
-      })}
-    </div>
-  );
 }
 
 export default function McpSection() {
@@ -391,9 +274,7 @@ export default function McpSection() {
                   />
                 );
               }}
-              getMoreInfoContent={(extension) => (
-                <RegistryDataViewer entry={extension.registryEntry} />
-              )}
+              getMoreInfoJson={(extension) => extension.registryEntry}
             />
           </TabsContent>
 
@@ -418,9 +299,7 @@ export default function McpSection() {
                   />
                 );
               }}
-              getMoreInfoContent={(extension) => (
-                <RegistryDataViewer entry={extension.registryEntry} />
-              )}
+              getMoreInfoJson={(extension) => extension.registryEntry}
             />
           </TabsContent>
 

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -218,7 +218,7 @@ export default function McpSection() {
     <div className="flex flex-col gap-6">
       <Card>
         <CardHeader>
-          <CardTitle>Extensions</CardTitle>
+          <CardTitle>Browse Extensions</CardTitle>
         </CardHeader>
         <CardContent>
           <ExtensionsBrowser

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -13,7 +13,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   mcpParallelLoadLimitAtom,
   mcpServersAtom,
@@ -216,54 +215,62 @@ export default function McpSection() {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>MCP Servers</CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-6">
-        <div className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
-          <div className="flex flex-1 flex-col items-start">
-            <Label
-              htmlFor="parallel-load-limit"
-              className="text-sm font-medium"
-            >
-              Parallel Load Limit
-            </Label>
-            <p className="text-muted-foreground mt-1 text-sm">
-              Maximum number of MCP servers to load concurrently.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Input
-              id="parallel-load-limit"
-              type="number"
-              min="1"
-              max="20"
-              value={parallelLoadLimit}
-              onChange={(e) =>
-                setParallelLoadLimit(parseInt(e.target.value) || 8)
-              }
-              className="w-20"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleResetParallelLoadLimit}
-              disabled={isParallelLoadLimitDefault}
-              aria-label="Reset to default"
-            >
-              <RotateCcwIcon className="size-4" />
-            </Button>
-          </div>
-        </div>
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Extensions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ExtensionsBrowser
+            isInstalled={isExtensionInstalled}
+            onInstallClick={handleExtensionInstallClick}
+            onUninstallClick={handleExtensionUninstallClick}
+          />
+        </CardContent>
+      </Card>
 
-        <Tabs defaultValue="servers" className="w-full">
-          <TabsList>
-            <TabsTrigger value="servers">Servers</TabsTrigger>
-            <TabsTrigger value="extensions">Extensions</TabsTrigger>
-          </TabsList>
+      <Card>
+        <CardHeader>
+          <CardTitle>Advanced</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center">
+            <div className="flex flex-1 flex-col items-start">
+              <Label
+                htmlFor="parallel-load-limit"
+                className="text-sm font-medium"
+              >
+                Parallel Load Limit
+              </Label>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Maximum number of MCP servers to load concurrently.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                id="parallel-load-limit"
+                type="number"
+                min="1"
+                max="20"
+                value={parallelLoadLimit}
+                onChange={(e) =>
+                  setParallelLoadLimit(parseInt(e.target.value) || 8)
+                }
+                className="w-20"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleResetParallelLoadLimit}
+                disabled={isParallelLoadLimitDefault}
+                aria-label="Reset to default"
+              >
+                <RotateCcwIcon className="size-4" />
+              </Button>
+            </div>
+          </div>
 
-          <TabsContent value="servers" className="mt-3 flex flex-col gap-3">
+          <div className="flex flex-col gap-3">
             <div className="flex items-center justify-between">
               <Label className="text-sm font-medium">Configured Servers</Label>
               <Button onClick={() => setShowAddDialog(true)} size="sm">
@@ -290,17 +297,9 @@ export default function McpSection() {
                 ))}
               </Accordion>
             )}
-          </TabsContent>
-
-          <TabsContent value="extensions" className="mt-3">
-            <ExtensionsBrowser
-              isInstalled={isExtensionInstalled}
-              onInstallClick={handleExtensionInstallClick}
-              onUninstallClick={handleExtensionUninstallClick}
-            />
-          </TabsContent>
-        </Tabs>
-      </CardContent>
+          </div>
+        </CardContent>
+      </Card>
 
       <AddServerDialog
         open={showAddDialog}
@@ -329,6 +328,6 @@ export default function McpSection() {
         onConfirm={handleConfirmExtensionUninstall}
         onCancel={handleCancelExtensionUninstall}
       />
-    </Card>
+    </div>
   );
 }

--- a/src/routes/settings/sections/mcp/index.tsx
+++ b/src/routes/settings/sections/mcp/index.tsx
@@ -1,13 +1,19 @@
 import { useAtom } from "jotai";
 import { RotateCcwIcon } from "lucide-react";
 import { useId, useState } from "react";
+import { toast } from "sonner";
 
+import {
+  type McpRegistryExtension,
+  type McpRegistryInstallResult,
+} from "@/assets/mcp-registry/mcp-registry";
 import { NoMcpServers } from "@/components/a1/empty-states/no-mcp-servers";
 import { Accordion } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   mcpParallelLoadLimitAtom,
   mcpServersAtom,
@@ -17,6 +23,8 @@ import { DEFAULT_SETTINGS, type McpServerConfig } from "@/lib/settings/types";
 
 import { AddServerDialog } from "./add-server-dialog";
 import { DeleteServerDialog } from "./delete-server-dialog";
+import { ExtensionsBrowser } from "./extensions-browser";
+import { InstallExtensionDialog } from "./install-extension-dialog";
 import { ServerListItem } from "./server-list-item";
 
 export default function McpSection() {
@@ -48,6 +56,9 @@ export default function McpSection() {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [serverToDelete, setServerToDelete] = useState<number | null>(null);
+  const [selectedExtension, setSelectedExtension] =
+    useState<McpRegistryExtension | null>(null);
+  const [showInstallDialog, setShowInstallDialog] = useState(false);
 
   const handleDeleteClick = (index: number) => {
     setServerToDelete(index);
@@ -103,6 +114,47 @@ export default function McpSection() {
     setMcpServers((prev) => [newServer, ...prev]);
   };
 
+  const handleInstallExtension = (installed: McpRegistryInstallResult) => {
+    const baseServer = {
+      id: `server-${uniqueId}-${crypto.randomUUID()}`,
+      name: installed.name,
+      enabled: true,
+      timeoutMs: installed.timeoutSec * 1000,
+      requiresApproval: installed.requiresApproval,
+    };
+
+    const newServer: McpServerConfig =
+      installed.type === "stdio"
+        ? {
+            ...baseServer,
+            type: "stdio",
+            command: installed.command,
+            env: installed.env,
+          }
+        : {
+            ...baseServer,
+            type: "http",
+            url: installed.url,
+            headers: installed.headers,
+          };
+
+    setMcpServers((prev) => [newServer, ...prev]);
+    toast.success(`${installed.name} installed`);
+  };
+
+  const handleExtensionInstallClick = (extension: McpRegistryExtension) => {
+    if (!extension.install) {
+      return;
+    }
+
+    setSelectedExtension(extension);
+    setShowInstallDialog(true);
+  };
+
+  const installedRegistryNames = new Set(
+    mcpServers.map((server) => server.name),
+  );
+
   return (
     <Card>
       <CardHeader>
@@ -145,32 +197,48 @@ export default function McpSection() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between">
-          <Label className="text-sm font-medium">Configured Servers</Label>
-          <Button onClick={() => setShowAddDialog(true)} size="sm">
-            Add Server
-          </Button>
-        </div>
+        <Tabs defaultValue="servers" className="w-full">
+          <TabsList>
+            <TabsTrigger value="servers">Servers</TabsTrigger>
+            <TabsTrigger value="extensions">Extensions</TabsTrigger>
+          </TabsList>
 
-        {mcpServers.length === 0 ? (
-          <NoMcpServers />
-        ) : (
-          <Accordion
-            type="single"
-            collapsible
-            className="border-border w-full rounded-md border"
-          >
-            {mcpServers.map((server, index) => (
-              <ServerListItem
-                key={server.id}
-                server={server}
-                index={index}
-                onUpdate={updateMcpServer}
-                onDelete={handleDeleteClick}
-              />
-            ))}
-          </Accordion>
-        )}
+          <TabsContent value="servers" className="mt-3 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium">Configured Servers</Label>
+              <Button onClick={() => setShowAddDialog(true)} size="sm">
+                Add Server
+              </Button>
+            </div>
+
+            {mcpServers.length === 0 ? (
+              <NoMcpServers />
+            ) : (
+              <Accordion
+                type="single"
+                collapsible
+                className="border-border w-full rounded-md border"
+              >
+                {mcpServers.map((server, index) => (
+                  <ServerListItem
+                    key={server.id}
+                    server={server}
+                    index={index}
+                    onUpdate={updateMcpServer}
+                    onDelete={handleDeleteClick}
+                  />
+                ))}
+              </Accordion>
+            )}
+          </TabsContent>
+
+          <TabsContent value="extensions" className="mt-3">
+            <ExtensionsBrowser
+              installedRegistryNames={installedRegistryNames}
+              onInstallClick={handleExtensionInstallClick}
+            />
+          </TabsContent>
+        </Tabs>
       </CardContent>
 
       <AddServerDialog
@@ -184,6 +252,13 @@ export default function McpSection() {
         onOpenChange={setShowDeleteDialog}
         onConfirm={confirmDelete}
         onCancel={cancelDelete}
+      />
+
+      <InstallExtensionDialog
+        extension={selectedExtension}
+        open={showInstallDialog}
+        onOpenChange={setShowInstallDialog}
+        onInstall={handleInstallExtension}
       />
     </Card>
   );

--- a/src/routes/settings/sections/mcp/install-extension-dialog.tsx
+++ b/src/routes/settings/sections/mcp/install-extension-dialog.tsx
@@ -1,0 +1,272 @@
+import { EyeIcon, EyeOffIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  createMcpServerFromRegistryInstall,
+  type McpRegistryExtension,
+  type McpRegistryInstallResult,
+  type RegistryInstallField,
+} from "@/assets/mcp-registry/mcp-registry";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface InstallExtensionDialogProps {
+  extension: McpRegistryExtension | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onInstall: (server: McpRegistryInstallResult) => void;
+}
+
+function InstallFieldInput({
+  field,
+  value,
+  onChange,
+}: {
+  field: RegistryInstallField;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const [showSecret, setShowSecret] = useState(false);
+
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={field.id} className="text-xs">
+        {field.label}
+        {field.required ? " *" : ""}
+      </Label>
+      <div className="flex items-center gap-2">
+        <Input
+          id={field.id}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={field.placeholder || undefined}
+          type={field.secret && !showSecret ? "password" : "text"}
+        />
+        {field.secret ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={() => setShowSecret((prev) => !prev)}
+            title={showSecret ? "Hide value" : "Show value"}
+          >
+            {showSecret ? (
+              <EyeOffIcon className="size-4" />
+            ) : (
+              <EyeIcon className="size-4" />
+            )}
+          </Button>
+        ) : null}
+      </div>
+      {field.description ? (
+        <p className="text-muted-foreground text-xs">{field.description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function InstallExtensionDialogBody({
+  extension,
+  onOpenChange,
+  onInstall,
+}: {
+  extension: McpRegistryExtension;
+  onOpenChange: (open: boolean) => void;
+  onInstall: (server: McpRegistryInstallResult) => void;
+}) {
+  const install = extension.install;
+  const defaultFieldValues = useMemo(() => {
+    if (!install) {
+      return {};
+    }
+
+    return install.fields.reduce<Record<string, string>>(
+      (accumulator, field) => {
+        accumulator[field.id] = field.defaultValue;
+        return accumulator;
+      },
+      {},
+    );
+  }, [install]);
+
+  const [name, setName] = useState(extension.displayName);
+  const [timeoutSec, setTimeoutSec] = useState(30);
+  const [requiresApproval, setRequiresApproval] = useState(false);
+  const [command, setCommand] = useState(install?.commandTemplate || "");
+  const [url, setUrl] = useState(install?.urlTemplate || "");
+  const [fieldValues, setFieldValues] =
+    useState<Record<string, string>>(defaultFieldValues);
+
+  if (!install) {
+    return null;
+  }
+
+  const requiredFields = install.fields.filter((field) => field.required);
+
+  const isFormValid =
+    name.trim() !== "" &&
+    timeoutSec >= 0.1 &&
+    (install.type === "stdio" ? command.trim() !== "" : url.trim() !== "") &&
+    requiredFields.every(
+      (field) => (fieldValues[field.id] || "").trim() !== "",
+    );
+
+  const handleInstall = () => {
+    if (!isFormValid) {
+      return;
+    }
+
+    const result = createMcpServerFromRegistryInstall(extension, {
+      name: name.trim(),
+      timeoutSec,
+      requiresApproval,
+      fieldValues,
+      command: install.type === "stdio" ? command : undefined,
+      url: install.type === "http" ? url : undefined,
+    });
+
+    if (!result) {
+      return;
+    }
+
+    onInstall(result);
+    onOpenChange(false);
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Install {extension.displayName}</DialogTitle>
+        <DialogDescription>
+          Review detected settings and install this MCP extension.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="grid gap-4 py-2">
+        <div className="grid gap-1.5">
+          <Label htmlFor="extension-server-name">Name</Label>
+          <Input
+            id="extension-server-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Server name"
+          />
+        </div>
+
+        {install.type === "stdio" ? (
+          <div className="grid gap-1.5">
+            <Label htmlFor="extension-command">Command</Label>
+            <Input
+              id="extension-command"
+              value={command}
+              onChange={(event) => setCommand(event.target.value)}
+              placeholder="npx -y ..."
+            />
+          </div>
+        ) : (
+          <div className="grid gap-1.5">
+            <Label htmlFor="extension-url">URL</Label>
+            <Input
+              id="extension-url"
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              placeholder="https://..."
+            />
+          </div>
+        )}
+
+        {install.fields.length > 0 ? (
+          <div className="rounded-md border p-3">
+            <p className="mb-3 text-xs font-medium">Detected configuration</p>
+            <div className="flex flex-col gap-3">
+              {install.fields.map((field) => (
+                <InstallFieldInput
+                  key={field.id}
+                  field={field}
+                  value={fieldValues[field.id] || ""}
+                  onChange={(value) =>
+                    setFieldValues((prev) => ({ ...prev, [field.id]: value }))
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-1.5">
+          <Label htmlFor="extension-timeout">Timeout (seconds)</Label>
+          <Input
+            id="extension-timeout"
+            type="number"
+            min="0.1"
+            max="300"
+            step="0.1"
+            value={timeoutSec}
+            onChange={(event) =>
+              setTimeoutSec(parseFloat(event.target.value) || 30)
+            }
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <Label htmlFor="extension-requires-approval" className="text-sm">
+              Require Approval
+            </Label>
+            <span className="text-muted-foreground text-xs">
+              Ask before running tools from this extension
+            </span>
+          </div>
+          <Switch
+            id="extension-requires-approval"
+            checked={requiresApproval}
+            onCheckedChange={setRequiresApproval}
+          />
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button onClick={handleInstall} disabled={!isFormValid}>
+          Install
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+export function InstallExtensionDialog({
+  extension,
+  open,
+  onOpenChange,
+  onInstall,
+}: InstallExtensionDialogProps) {
+  if (!extension) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
+        <InstallExtensionDialogBody
+          key={`${extension.id}-${open ? "open" : "closed"}`}
+          extension={extension}
+          onOpenChange={onOpenChange}
+          onInstall={onInstall}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/settings/sections/mcp/server-list-item.tsx
+++ b/src/routes/settings/sections/mcp/server-list-item.tsx
@@ -72,14 +72,16 @@ export function ServerListItem({
               <Input
                 id={`timeout-${server.id}`}
                 type="number"
-                min="1"
+                min="0.1"
                 max="300"
-                value={Math.round(server.timeoutMs / 1000)}
-                onChange={(e) =>
+                step="0.1"
+                value={server.timeoutMs / 1000}
+                onChange={(e) => {
+                  const seconds = parseFloat(e.target.value);
                   onUpdate(index, {
-                    timeoutMs: (parseInt(e.target.value) || 30) * 1000,
-                  })
-                }
+                    timeoutMs: seconds * 1000,
+                  });
+                }}
                 placeholder="30"
               />
             </div>

--- a/src/routes/settings/sections/mcp/uninstall-extension-dialog.tsx
+++ b/src/routes/settings/sections/mcp/uninstall-extension-dialog.tsx
@@ -1,0 +1,53 @@
+import type { McpRegistryExtension } from "@/assets/mcp-registry/mcp-registry";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface UninstallExtensionDialogProps {
+  extension: McpRegistryExtension | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function UninstallExtensionDialog({
+  extension,
+  open,
+  onOpenChange,
+  onConfirm,
+  onCancel,
+}: UninstallExtensionDialogProps) {
+  if (!extension) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Uninstall {extension.displayName}</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to uninstall this extension? Its MCP server
+            configuration will be removed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            Uninstall
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/routes/tests/index.tsx
+++ b/src/routes/tests/index.tsx
@@ -32,7 +32,7 @@ export default function TestsRoute() {
               <CardTitle>Available Tests</CardTitle>
             </CardHeader>
             <CardContent className="flex flex-col gap-4">
-              <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="flex items-center justify-between rounded-md border p-4">
                 <div>
                   <h3 className="font-medium">Notifications</h3>
                   <p className="text-muted-foreground text-sm">
@@ -46,7 +46,7 @@ export default function TestsRoute() {
                   Run Test
                 </Button>
               </div>
-              <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="flex items-center justify-between rounded-md border p-4">
                 <div>
                   <h3 className="font-medium">Trigger Onboarding</h3>
                   <p className="text-muted-foreground text-sm">

--- a/src/routes/tests/notifications/index.tsx
+++ b/src/routes/tests/notifications/index.tsx
@@ -126,7 +126,7 @@ export default function NotificationsTestRoute() {
                 <CardTitle>Logs</CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="bg-muted/20 max-h-96 overflow-y-auto rounded-lg border p-4">
+                <div className="bg-muted/20 max-h-96 overflow-y-auto rounded-md border p-4">
                   <pre className="font-mono text-xs whitespace-pre-wrap">
                     {logs.join("\n")}
                   </pre>


### PR DESCRIPTION
WIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse, search and score MCP extensions in a new Extensions Browser; install/uninstall directly from settings.
  * Install flow supports multiple install types (stdio or http) and collects required configuration via an install dialog.

* **UI/UX**
  * "MCP Servers" renamed to "Extensions" in settings; added install/uninstall dialogs and success toasts.

* **Chores**
  * Removed local MCP server (development) option and related package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->