### PR TITLE
feat: smarter pr-tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -103,7 +103,8 @@ jobs:
       - name: Check for E2E marker in current commit
         id: marker
         run: |
-          if git log --format=%B -1 HEAD | grep -Fq '[e2e]'; then
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if git log --format=%B -1 "$HEAD_SHA" | grep -Fq '[e2e]'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -37,10 +37,6 @@ jobs:
 
   test:
     needs: changes
-    if: >-
-      (matrix.test != 'rust-check' && matrix.test != 'e2e') ||
-      (matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true') ||
-      (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -56,7 +52,7 @@ jobs:
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
         with:
           bun-version: latest
-        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || matrix.test == 'e2e'
+        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
 
       - name: Cache bun dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -67,16 +63,16 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || matrix.test == 'e2e'
+        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
 
       - name: Install JS dependencies
         run: bun install --frozen-lockfile
-        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || matrix.test == 'e2e'
+        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
 
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(bun -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
-        if: matrix.test == 'e2e'
+        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Cache Playwright browsers
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -84,34 +80,34 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-        if: matrix.test == 'e2e'
+        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps
-        if: matrix.test == 'e2e'
+        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Install Playwright browsers
         run: bunx playwright install
-        if: matrix.test == 'e2e' && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Cache and install Tauri system dependencies
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
           version: 1.1
-        if: matrix.test == 'rust-check'
+        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
-        if: matrix.test == 'rust-check'
+        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: "src-tauri -> target"
-        if: matrix.test == 'rust-check'
+        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
 
       - name: Run Type Checking
         run: bun run typecheck
@@ -127,21 +123,21 @@ jobs:
 
       - name: Build Project for E2E
         run: bun run build
-        if: matrix.test == 'e2e'
+        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Run E2E Playwright Tests
         run: bun run test:e2e
         env:
           CI: true
-        if: matrix.test == 'e2e'
+        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Run Rust Cargo Check
         run: cd src-tauri && cargo check
-        if: matrix.test == 'rust-check'
+        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: always() && matrix.test == 'e2e'
+        if: always() && matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
         with:
           name: playwright-report-${{ matrix.test }}
           path: playwright-report/
@@ -149,7 +145,7 @@ jobs:
 
       - name: Upload Test Results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: always() && matrix.test == 'e2e'
+        if: always() && matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
         with:
           name: test-results-${{ matrix.test }}
           path: test-results/

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -99,6 +99,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Check for E2E marker in current commit
         id: marker

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,39 +5,8 @@ on:
     branches: [main]
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      tauri_changed: ${{ steps.filter.outputs.tauri_changed }}
-      run_e2e: ${{ steps.filter.outputs.run_e2e }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Detect changed paths and E2E commit marker
-        id: filter
-        shell: bash
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -q '^src-tauri/'; then
-            echo "tauri_changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tauri_changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if git log --format=%B "$BASE_SHA..$HEAD_SHA" | grep -Fq '[e2e]'; then
-            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  js-checks:
-    name: Typecheck · Lint · Format
-    needs: changes
+  typecheck:
+    name: Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -65,18 +34,10 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-      - name: Lint
-        run: bun run lint
-
-      - name: Format
-        run: bun run fmt:check
-
-  e2e:
-    name: E2E Tests
-    needs: changes
-    if: needs.changes.outputs.run_e2e == 'true'
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -99,9 +60,81 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Lint
+        run: bun run lint
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format
+        run: bun run fmt:check
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check for E2E marker in current commit
+        id: marker
+        run: |
+          if git log --format=%B -1 HEAD | grep -Fq '[e2e]'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping E2E: current commit does not contain [e2e]"
+          fi
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: latest
+        if: steps.marker.outputs.run == 'true'
+
+      - name: Cache bun dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+        if: steps.marker.outputs.run == 'true'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        if: steps.marker.outputs.run == 'true'
+
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(bun -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
+        if: steps.marker.outputs.run == 'true'
 
       - name: Cache Playwright browsers
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -109,25 +142,29 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+        if: steps.marker.outputs.run == 'true'
 
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps
+        if: steps.marker.outputs.run == 'true'
 
       - name: Install Playwright browsers
         run: bunx playwright install
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: steps.marker.outputs.run == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Build
         run: bun run build
+        if: steps.marker.outputs.run == 'true'
 
       - name: Run Playwright tests
         run: bun run test:e2e
         env:
           CI: true
+        if: steps.marker.outputs.run == 'true'
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: always()
+        if: always() && steps.marker.outputs.run == 'true'
         with:
           name: playwright-report
           path: playwright-report/
@@ -135,38 +172,54 @@ jobs:
 
       - name: Upload test results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: always()
+        if: always() && steps.marker.outputs.run == 'true'
         with:
           name: test-results
           path: test-results/
           retention-days: 1
 
-  rust-checks:
+  rust-clippy:
     name: Rust Clippy
-    needs: changes
-    if: needs.changes.outputs.tauri_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check for Tauri changes
+        id: changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -q '^src-tauri/'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: no changes in src-tauri/"
+          fi
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
           version: 1.1
+        if: steps.changes.outputs.run == 'true'
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           components: clippy
+        if: steps.changes.outputs.run == 'true'
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: "src-tauri -> target"
+        if: steps.changes.outputs.run == 'true'
 
       - name: Run Clippy
         run: cd src-tauri && cargo clippy
+        if: steps.changes.outputs.run == 'true'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,7 +5,42 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tauri_changed: ${{ steps.filter.outputs.tauri_changed }}
+      run_e2e: ${{ steps.filter.outputs.run_e2e }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths and E2E commit marker
+        id: filter
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -q '^src-tauri/'; then
+            echo "tauri_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tauri_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git log --format=%B "$BASE_SHA..$HEAD_SHA" | grep -Fq '[e2e]'; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: changes
+    if: >-
+      (matrix.test != 'rust-check' && matrix.test != 'e2e') ||
+      (matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true') ||
+      (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -35,15 +35,11 @@ jobs:
             echo "run_e2e=false" >> "$GITHUB_OUTPUT"
           fi
 
-  test:
+  js-checks:
+    name: Typecheck · Lint · Format
     needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      fail-fast: true
-      matrix:
-        test: [typecheck, lint, format-check, e2e, rust-check]
-
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,7 +48,6 @@ jobs:
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
         with:
           bun-version: latest
-        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
 
       - name: Cache bun dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -63,16 +58,50 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
 
-      - name: Install JS dependencies
+      - name: Install dependencies
         run: bun install --frozen-lockfile
-        if: matrix.test == 'typecheck' || matrix.test == 'lint' || matrix.test == 'format-check' || (matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true')
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Format
+        run: bun run fmt:check
+
+  e2e:
+    name: E2E Tests
+    needs: changes
+    if: needs.changes.outputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+        with:
+          bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(bun -e "console.log(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
-        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Cache Playwright browsers
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -80,73 +109,64 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Install Playwright system dependencies
         run: bunx playwright install-deps
-        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
 
       - name: Install Playwright browsers
         run: bunx playwright install
-        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - name: Cache and install Tauri system dependencies
+      - name: Build
+        run: bun run build
+
+      - name: Run Playwright tests
+        run: bun run test:e2e
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 1
+
+      - name: Upload test results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 1
+
+  rust-checks:
+    name: Rust Clippy
+    needs: changes
+    if: needs.changes.outputs.tauri_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
           version: 1.1
-        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
-        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
+          components: clippy
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: "src-tauri -> target"
-        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
 
-      - name: Run Type Checking
-        run: bun run typecheck
-        if: matrix.test == 'typecheck'
-
-      - name: Run Linting
-        run: bun run lint
-        if: matrix.test == 'lint'
-
-      - name: Run Format Check
-        run: bun run fmt:check
-        if: matrix.test == 'format-check'
-
-      - name: Build Project for E2E
-        run: bun run build
-        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
-
-      - name: Run E2E Playwright Tests
-        run: bun run test:e2e
-        env:
-          CI: true
-        if: matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
-
-      - name: Run Rust Cargo Check
-        run: cd src-tauri && cargo check
-        if: matrix.test == 'rust-check' && needs.changes.outputs.tauri_changed == 'true'
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: always() && matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
-        with:
-          name: playwright-report-${{ matrix.test }}
-          path: playwright-report/
-          retention-days: 1
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: always() && matrix.test == 'e2e' && needs.changes.outputs.run_e2e == 'true'
-        with:
-          name: test-results-${{ matrix.test }}
-          path: test-results/
-          retention-days: 1
+      - name: Run Clippy
+        run: cd src-tauri && cargo clippy

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See https://tauri.app/plugin/updater/.
 
 ## PR Tests
 
-- To run e2e tests on a commit in your PR, add `[e2e]` to the commit message.
+- To run E2E tests on a commit in your PR, add `[e2e]` to the commit message. E2E tests will only run if the _current_ commit message contains `[e2e]`, even previous commit messages also contain `[e2e]`.
 - Rust checks will only run if `src-tauri/` has changed.
 
 ---

--- a/README.md
+++ b/README.md
@@ -93,5 +93,3 @@ Copyright © 2026 bestcodes.dev
 All rights reserved.
 
 This code is proprietary and confidential. No license is granted to use, copy, modify, distribute, or create derivative works of this software except with explicit written permission from the copyright holder.
-
-rmme

--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ Copyright © 2026 bestcodes.dev
 All rights reserved.
 
 This code is proprietary and confidential. No license is granted to use, copy, modify, distribute, or create derivative works of this software except with explicit written permission from the copyright holder.
+
+rmme

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ See https://tauri.app/plugin/updater/.
 - `bunx -y playwright test` to run all tests in all projects
 - `bunx -y playwright test --project="chromium-desktop-light" --project="pixel-7-dark"` to run only fast Chromium tests
 
+## PR Tests
+
+- To run e2e tests on a commit in your PR, add `[e2e]` to the commit message.
+
 ---
 
 Copyright © 2026 bestcodes.dev

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ See https://tauri.app/plugin/updater/.
 ## PR Tests
 
 - To run e2e tests on a commit in your PR, add `[e2e]` to the commit message.
+- Rust checks will only run if `src-tauri/` has changed.
 
 ---
 


### PR DESCRIPTION
WIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked CI: tests split into independent jobs (typecheck, lint, format, E2E) and a dedicated Rust check job; jobs run independently and are only executed when relevant.
  * Standardized CI step names and artifact naming; E2E artifacts and runs are gated by an explicit marker so they only run when requested.
* **Documentation**
  * Added "PR Tests" guidance to README explaining how to trigger E2E runs and that native/Rust checks run only when native changes are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->