### PR TITLE
extension statuses and per-tool approval controls

### DIFF
--- a/src/contexts/use-tools/tools-context.tsx
+++ b/src/contexts/use-tools/tools-context.tsx
@@ -15,7 +15,7 @@ import {
   invalidateServerCache,
   prefixMcpToolNames,
 } from "@/lib/ai/tools/mcp";
-import { mcpAuthStatesAtom } from "@/lib/jotai/mcp-atoms";
+import { mcpAuthStatesAtom, mcpServerLoadStatesAtom } from "@/lib/jotai/mcp-atoms";
 import {
   enabledToolsAtom,
   mcpParallelLoadLimitAtom,
@@ -39,16 +39,16 @@ interface ToolsProviderProps {
   children: ReactNode;
 }
 
-function applyNeedsApprovalToTools(tools: ToolSet, needsApproval: boolean): ToolSet {
-  if (!needsApproval) {
-    return tools;
-  }
-
+function applyApprovalConfigToTools(
+  tools: ToolSet,
+  defaultNeedsApproval: boolean,
+  toolApprovalOverrides: Record<string, boolean> = {},
+): ToolSet {
   const wrappedTools: ToolSet = {};
   for (const [name, tool] of Object.entries(tools)) {
     wrappedTools[name] = {
       ...tool,
-      needsApproval: true,
+      needsApproval: toolApprovalOverrides[name] ?? defaultNeedsApproval,
     } as Tool<unknown, unknown>;
   }
   return wrappedTools;
@@ -60,6 +60,7 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
   const [parallelLoadLimit] = useAtom(mcpParallelLoadLimitAtom);
   const [toolConfigs] = useAtom(toolConfigsAtom);
   const [mcpAuthStates] = useAtom(mcpAuthStatesAtom);
+  const [, setMcpServerLoadStates] = useAtom(mcpServerLoadStatesAtom);
 
   const [mcpTools, setMcpTools] = useState<ToolSet>({});
   const [isMcpLoading, setIsMcpLoading] = useState(false);
@@ -81,6 +82,22 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
       ? mcpServers.filter((server) => server.enabled)
       : [];
 
+    setMcpServerLoadStates((prev) => {
+      const next: Record<string, (typeof prev)[string]> = {};
+
+      for (const server of mcpServers) {
+        const previous = prev[server.id];
+        next[server.id] = {
+          status: server.enabled ? (previous?.status ?? "unknown") : "disabled",
+          toolCount: previous?.toolCount ?? 0,
+          toolNames: previous?.toolNames ?? [],
+          error: server.enabled ? previous?.error : undefined,
+        };
+      }
+
+      return next;
+    });
+
     const newEnabledIds = new Set(enabledServers.map((server) => server.id));
     for (const serverId of enabledServerIdsRef.current) {
       if (!newEnabledIds.has(serverId)) {
@@ -97,6 +114,19 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
       setMcpTools({});
       setMcpLoaded(true);
       setIsMcpLoading(false);
+      setMcpServerLoadStates((prev) => {
+        const next = { ...prev };
+
+        for (const server of mcpServers) {
+          next[server.id] = {
+            status: server.enabled ? "unknown" : "disabled",
+            toolCount: 0,
+            toolNames: [],
+          };
+        }
+
+        return next;
+      });
       return;
     }
 
@@ -106,6 +136,20 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
       mcpLoadedRef.current = false;
       setIsMcpLoading(true);
       setMcpLoaded(false);
+      setMcpServerLoadStates((prev) => {
+        const next = { ...prev };
+
+        for (const server of enabledServers) {
+          const previous = prev[server.id];
+          next[server.id] = {
+            status: server.type === "stdio" ? "starting" : "connecting",
+            toolCount: previous?.toolCount ?? 0,
+            toolNames: previous?.toolNames ?? [],
+          };
+        }
+
+        return next;
+      });
 
       try {
         const slugMap = buildMcpServerSlugMap(enabledServers);
@@ -132,12 +176,17 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
                     ),
                   ),
                 ]);
-                const wrappedTools = applyNeedsApprovalToTools(
+                const toolNames = Object.keys(tools);
+                const wrappedTools = applyApprovalConfigToTools(
                   tools,
                   server.requiresApproval ?? false,
+                  server.toolApprovalOverrides,
                 );
                 return {
+                  server,
                   serverSlug: slugMap.get(server.id) ?? server.id,
+                  status: "loaded" as const,
+                  toolNames,
                   tools: wrappedTools,
                 };
               } catch (error) {
@@ -148,7 +197,11 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
                 );
                 closeServerCache(server.id);
                 return {
+                  server,
                   serverSlug: slugMap.get(server.id) ?? server.id,
+                  error: error instanceof Error ? error.message : "Unknown error",
+                  status: "error" as const,
+                  toolNames: [],
                   tools: {},
                 };
               }
@@ -158,6 +211,29 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
           for (const result of results) {
             Object.assign(allTools, prefixMcpToolNames(result.tools, result.serverSlug));
           }
+
+          setMcpServerLoadStates((prev) => {
+            const next = { ...prev };
+
+            for (const result of results) {
+              const previous = prev[result.server.id];
+              next[result.server.id] =
+                result.status === "loaded"
+                  ? {
+                      status: "loaded",
+                      toolCount: result.toolNames.length,
+                      toolNames: result.toolNames,
+                    }
+                  : {
+                      status: "error",
+                      toolCount: previous?.toolCount ?? 0,
+                      toolNames: previous?.toolNames ?? [],
+                      error: result.error,
+                    };
+            }
+
+            return next;
+          });
         }
 
         if (loadId !== loadIdRef.current) return;
@@ -172,6 +248,21 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
         mcpLoadedRef.current = true;
         setMcpTools({});
         setMcpLoaded(true);
+        setMcpServerLoadStates((prev) => {
+          const next = { ...prev };
+
+          for (const server of enabledServers) {
+            const previous = prev[server.id];
+            next[server.id] = {
+              status: "error",
+              toolCount: previous?.toolCount ?? 0,
+              toolNames: previous?.toolNames ?? [],
+              error: error instanceof Error ? error.message : "Unknown error",
+            };
+          }
+
+          return next;
+        });
       } finally {
         setIsMcpLoading(false);
       }
@@ -179,7 +270,7 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
 
     const promise = loadMcpTools();
     loadingPromiseRef.current = promise;
-  }, [mcpServers, parallelLoadLimit, mcpAuthStates]);
+  }, [mcpServers, parallelLoadLimit, mcpAuthStates, setMcpServerLoadStates]);
 
   const getTools = useCallback(async (): Promise<ToolSet> => {
     const filteredStaticTools: ToolSet = {};

--- a/src/lib/jotai/mcp-atoms.ts
+++ b/src/lib/jotai/mcp-atoms.ts
@@ -3,7 +3,24 @@ import { atomWithStorage } from "jotai/utils";
 
 export type McpAuthState = "logged-in" | "logged-out" | "no-auth" | "supports-oauth" | undefined;
 
+export type McpServerLoadStatus =
+  | "unknown"
+  | "disabled"
+  | "starting"
+  | "connecting"
+  | "loaded"
+  | "error";
+
+export interface McpServerLoadState {
+  status: McpServerLoadStatus;
+  toolCount: number;
+  toolNames: string[];
+  error?: string;
+}
+
 export const mcpAuthStatesAtom = atom<Record<string, McpAuthState>>({});
+
+export const mcpServerLoadStatesAtom = atom<Record<string, McpServerLoadState>>({});
 
 export const dismissedOAuthPromptsAtom = atomWithStorage<string[]>(
   "agent-one-dismissed-oauth-prompts",

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -44,6 +44,7 @@ export interface McpServerConfigBase {
   enabled: boolean;
   timeoutMs: number;
   requiresApproval: boolean;
+  toolApprovalOverrides?: Record<string, boolean>;
 }
 
 export interface McpStdioServerConfig extends McpServerConfigBase {

--- a/src/routes/settings/sections/extensions/extension-advanced-details.tsx
+++ b/src/routes/settings/sections/extensions/extension-advanced-details.tsx
@@ -1,9 +1,13 @@
+import { useAtomValue } from "jotai";
+
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { mcpServerLoadStatesAtom } from "@/lib/jotai/mcp-atoms";
 import { type McpServerConfig } from "@/lib/settings/types";
 
 import { McpAuthStatus } from "./mcp-auth-status";
 import { McpServerConfigForm } from "./mcp-server-config-form";
+import { McpServerStatus } from "./mcp-server-status";
 
 interface ExtensionAdvancedDetailsProps {
   server: McpServerConfig;
@@ -11,6 +15,9 @@ interface ExtensionAdvancedDetailsProps {
 }
 
 export function ExtensionAdvancedDetails({ server, onUpdate }: ExtensionAdvancedDetailsProps) {
+  const loadStates = useAtomValue(mcpServerLoadStatesAtom);
+  const loadState = loadStates[server.id];
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
@@ -29,6 +36,8 @@ export function ExtensionAdvancedDetails({ server, onUpdate }: ExtensionAdvanced
         />
       </div>
 
+      <McpServerStatus state={loadState} disabled={!server.enabled} />
+
       <McpServerConfigForm
         idPrefix={server.id}
         values={{
@@ -40,6 +49,7 @@ export function ExtensionAdvancedDetails({ server, onUpdate }: ExtensionAdvanced
           headers: server.type === "http" ? server.headers : {},
           timeoutSec: server.timeoutMs / 1000,
           requiresApproval: server.requiresApproval,
+          toolApprovalOverrides: server.toolApprovalOverrides,
         }}
         onChange={(updates) => {
           if (updates.name !== undefined) {
@@ -63,8 +73,12 @@ export function ExtensionAdvancedDetails({ server, onUpdate }: ExtensionAdvanced
           if (updates.requiresApproval !== undefined) {
             onUpdate({ requiresApproval: updates.requiresApproval });
           }
+          if (updates.toolApprovalOverrides !== undefined) {
+            onUpdate({ toolApprovalOverrides: updates.toolApprovalOverrides });
+          }
         }}
         approvalDescription="Ask for confirmation before running tools"
+        availableTools={loadState?.toolNames ?? []}
         httpSupplement={
           server.type === "http" ? (
             <McpAuthStatus server={server} disabled={!server.enabled} />

--- a/src/routes/settings/sections/extensions/extension-advanced-details.tsx
+++ b/src/routes/settings/sections/extensions/extension-advanced-details.tsx
@@ -1,11 +1,10 @@
 import { useAtomValue } from "jotai";
 
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { mcpServerLoadStatesAtom } from "@/lib/jotai/mcp-atoms";
 import { type McpServerConfig } from "@/lib/settings/types";
 
 import { McpAuthStatus } from "./mcp-auth-status";
+import { McpServerApprovalSettings } from "./mcp-server-approval-settings";
 import { McpServerConfigForm } from "./mcp-server-config-form";
 import { McpServerStatus } from "./mcp-server-status";
 
@@ -20,23 +19,25 @@ export function ExtensionAdvancedDetails({ server, onUpdate }: ExtensionAdvanced
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col">
-          <Label htmlFor={`enabled-${server.id}`} className="text-sm">
-            Enabled
-          </Label>
-          <span className="text-muted-foreground text-xs">
-            Load this extension when tools initialize
-          </span>
-        </div>
-        <Switch
-          id={`enabled-${server.id}`}
-          checked={server.enabled}
-          onCheckedChange={(checked) => onUpdate({ enabled: checked })}
-        />
-      </div>
+      <McpServerStatus
+        state={loadState}
+        disabled={!server.enabled}
+        switchId={`enabled-${server.id}`}
+        onEnabledChange={(checked) => onUpdate({ enabled: checked })}
+      />
 
-      <McpServerStatus state={loadState} disabled={!server.enabled} />
+      <McpServerApprovalSettings
+        idPrefix={server.id}
+        enabled={server.enabled}
+        requiresApproval={server.requiresApproval}
+        toolApprovalOverrides={server.toolApprovalOverrides}
+        loadState={loadState}
+        approvalDescription="Ask for confirmation before running tools"
+        onRequiresApprovalChange={(requiresApproval) => onUpdate({ requiresApproval })}
+        onToolApprovalOverridesChange={(toolApprovalOverrides) =>
+          onUpdate({ toolApprovalOverrides })
+        }
+      />
 
       <McpServerConfigForm
         idPrefix={server.id}
@@ -49,7 +50,6 @@ export function ExtensionAdvancedDetails({ server, onUpdate }: ExtensionAdvanced
           headers: server.type === "http" ? server.headers : {},
           timeoutSec: server.timeoutMs / 1000,
           requiresApproval: server.requiresApproval,
-          toolApprovalOverrides: server.toolApprovalOverrides,
         }}
         onChange={(updates) => {
           if (updates.name !== undefined) {
@@ -70,15 +70,8 @@ export function ExtensionAdvancedDetails({ server, onUpdate }: ExtensionAdvanced
           if (updates.timeoutSec !== undefined) {
             onUpdate({ timeoutMs: updates.timeoutSec * 1000 });
           }
-          if (updates.requiresApproval !== undefined) {
-            onUpdate({ requiresApproval: updates.requiresApproval });
-          }
-          if (updates.toolApprovalOverrides !== undefined) {
-            onUpdate({ toolApprovalOverrides: updates.toolApprovalOverrides });
-          }
         }}
-        approvalDescription="Ask for confirmation before running tools"
-        availableTools={loadState?.toolNames ?? []}
+        showApprovalControls={false}
         httpSupplement={
           server.type === "http" ? (
             <McpAuthStatus server={server} disabled={!server.enabled} />

--- a/src/routes/settings/sections/extensions/extension-list-row.tsx
+++ b/src/routes/settings/sections/extensions/extension-list-row.tsx
@@ -19,6 +19,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { type McpServerLoadState } from "@/lib/jotai/mcp-atoms";
+
+import { ExtensionRowActions } from "./extension-row-actions";
 
 interface ExtensionListRowProps {
   title: string;
@@ -31,6 +34,9 @@ interface ExtensionListRowProps {
   installSupported?: boolean;
   onInstall?: () => void;
   onUninstall?: () => void;
+  enabled?: boolean;
+  loadState?: McpServerLoadState;
+  onEnabledChange?: (enabled: boolean) => void;
   advancedContent?: ReactNode;
   moreInfoJson?: unknown;
 }
@@ -46,6 +52,9 @@ export function ExtensionListRow({
   installSupported = true,
   onInstall,
   onUninstall,
+  enabled,
+  loadState,
+  onEnabledChange,
   advancedContent,
   moreInfoJson,
 }: ExtensionListRowProps) {
@@ -96,6 +105,13 @@ export function ExtensionListRow({
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
+          {installed && enabled !== undefined && onEnabledChange ? (
+            <ExtensionRowActions
+              enabled={enabled}
+              loadState={loadState}
+              onEnabledChange={onEnabledChange}
+            />
+          ) : null}
           {installed ? (
             <Button size="sm" variant="destructive" onClick={onUninstall}>
               <IconTrash data-icon="inline-start" />

--- a/src/routes/settings/sections/extensions/extension-list-row.tsx
+++ b/src/routes/settings/sections/extensions/extension-list-row.tsx
@@ -105,13 +105,6 @@ export function ExtensionListRow({
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          {installed && enabled !== undefined && onEnabledChange ? (
-            <ExtensionRowActions
-              enabled={enabled}
-              loadState={loadState}
-              onEnabledChange={onEnabledChange}
-            />
-          ) : null}
           {installed ? (
             <Button size="sm" variant="destructive" onClick={onUninstall}>
               <IconTrash data-icon="inline-start" />
@@ -122,6 +115,13 @@ export function ExtensionListRow({
               {installSupported ? "Install" : "Unsupported"}
             </Button>
           )}
+          {installed && enabled !== undefined && onEnabledChange ? (
+            <ExtensionRowActions
+              enabled={enabled}
+              loadState={loadState}
+              onEnabledChange={onEnabledChange}
+            />
+          ) : null}
         </div>
       </div>
 

--- a/src/routes/settings/sections/extensions/extension-row-actions.tsx
+++ b/src/routes/settings/sections/extensions/extension-row-actions.tsx
@@ -1,0 +1,44 @@
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { type McpServerLoadState } from "@/lib/jotai/mcp-atoms";
+
+import { McpServerStatus } from "./mcp-server-status";
+import { getMcpServerStatusTooltip } from "./mcp-server-status-utils";
+
+interface ExtensionRowActionsProps {
+  enabled: boolean;
+  loadState?: McpServerLoadState;
+  onEnabledChange: (enabled: boolean) => void;
+}
+
+export function ExtensionRowActions({
+  enabled,
+  loadState,
+  onEnabledChange,
+}: ExtensionRowActionsProps) {
+  const toolCount = loadState?.status === "loaded" ? loadState.toolCount : null;
+
+  return (
+    <div className="bg-background flex items-center gap-3 rounded-md border px-3 py-2">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center">
+            <McpServerStatus state={loadState} disabled={!enabled} compact />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>{getMcpServerStatusTooltip(loadState, !enabled)}</TooltipContent>
+      </Tooltip>
+
+      {toolCount !== null ? (
+        <span className="text-muted-foreground text-xs">
+          {toolCount === 1 ? "1 tool" : `${toolCount} tools`}
+        </span>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        <span className="text-xs">Enabled</span>
+        <Switch checked={enabled} onCheckedChange={onEnabledChange} aria-label="Toggle extension" />
+      </div>
+    </div>
+  );
+}

--- a/src/routes/settings/sections/extensions/extension-row-actions.tsx
+++ b/src/routes/settings/sections/extensions/extension-row-actions.tsx
@@ -19,7 +19,7 @@ export function ExtensionRowActions({
   const toolCount = loadState?.status === "loaded" ? loadState.toolCount : null;
 
   return (
-    <div className="bg-background flex items-center gap-3 rounded-md border px-3 py-2">
+    <div className="bg-muted dark:bg-input/30 border-border flex h-7 items-center gap-1 rounded-[min(var(--radius-md),12px)] border px-2.5 text-[0.8rem]">
       <Tooltip>
         <TooltipTrigger asChild>
           <div className="flex items-center">
@@ -28,17 +28,19 @@ export function ExtensionRowActions({
         </TooltipTrigger>
         <TooltipContent>{getMcpServerStatusTooltip(loadState, !enabled)}</TooltipContent>
       </Tooltip>
-
       {toolCount !== null ? (
         <span className="text-muted-foreground text-xs">
           {toolCount === 1 ? "1 tool" : `${toolCount} tools`}
         </span>
       ) : null}
 
-      <div className="flex items-center gap-2">
-        <span className="text-xs">Enabled</span>
-        <Switch checked={enabled} onCheckedChange={onEnabledChange} aria-label="Toggle extension" />
-      </div>
+      <Switch
+        size="sm"
+        className="ml-1"
+        checked={enabled}
+        onCheckedChange={onEnabledChange}
+        aria-label="Toggle extension"
+      />
     </div>
   );
 }

--- a/src/routes/settings/sections/extensions/extensions-browser.tsx
+++ b/src/routes/settings/sections/extensions/extensions-browser.tsx
@@ -8,6 +8,8 @@ import {
   type McpRegistryExtension,
 } from "@/assets/mcp-registry/mcp-registry";
 import { useOverflow } from "@/hooks/use-overflow";
+import { type McpServerLoadState } from "@/lib/jotai/mcp-atoms";
+import { type McpServerConfig } from "@/lib/settings/types";
 import { cn } from "@/lib/utils";
 
 import { ExtensionListRow } from "./extension-list-row";
@@ -20,8 +22,11 @@ interface ExtensionsBrowserProps {
   showDeviceExtensions: boolean;
   showOnlineExtensions: boolean;
   isInstalled: (extension: McpRegistryExtension) => boolean;
+  getServerForExtension?: (extension: McpRegistryExtension) => McpServerConfig | undefined;
+  getLoadStateForExtension?: (extension: McpRegistryExtension) => McpServerLoadState | undefined;
   onInstallClick: (extension: McpRegistryExtension) => void;
   onUninstallClick: (extension: McpRegistryExtension) => void;
+  onEnabledChange?: (serverId: string, enabled: boolean) => void;
   getAdvancedContent?: (extension: McpRegistryExtension) => ReactNode;
   getMoreInfoJson?: (extension: McpRegistryExtension) => unknown;
 }
@@ -32,8 +37,11 @@ export function ExtensionsBrowser({
   showDeviceExtensions,
   showOnlineExtensions,
   isInstalled,
+  getServerForExtension,
+  getLoadStateForExtension,
   onInstallClick,
   onUninstallClick,
+  onEnabledChange,
   getAdvancedContent,
   getMoreInfoJson,
 }: ExtensionsBrowserProps) {
@@ -124,6 +132,7 @@ export function ExtensionsBrowser({
             {virtualizer.getVirtualItems().map((virtualItem) => {
               const extension = filteredExtensions[virtualItem.index];
               const installed = isInstalled(extension);
+              const server = getServerForExtension?.(extension);
 
               return (
                 <div
@@ -144,6 +153,13 @@ export function ExtensionsBrowser({
                     badges={extension.categories.length > 0 ? extension.categories : extension.tags}
                     installed={installed}
                     installSupported={Boolean(extension.install)}
+                    enabled={server?.enabled}
+                    loadState={getLoadStateForExtension?.(extension)}
+                    onEnabledChange={
+                      server && onEnabledChange
+                        ? (enabled) => onEnabledChange(server.id, enabled)
+                        : undefined
+                    }
                     onInstall={() => onInstallClick(extension)}
                     onUninstall={() => onUninstallClick(extension)}
                     advancedContent={

--- a/src/routes/settings/sections/extensions/index.tsx
+++ b/src/routes/settings/sections/extensions/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { mcpServerLoadStatesAtom } from "@/lib/jotai/mcp-atoms";
 import { mcpServersAtom } from "@/lib/jotai/settings-atoms";
 import { type McpServerConfig } from "@/lib/settings/types";
 
@@ -53,6 +54,7 @@ function isServerFromRegistry(server: McpServerConfig): boolean {
 
 export default function ExtensionsSection() {
   const [mcpServers, setMcpServers] = useAtom(mcpServersAtom);
+  const [mcpServerLoadStates] = useAtom(mcpServerLoadStatesAtom);
   const [searchParams, setSearchParams] = useSearchParams();
 
   const mcpInstallPrefill = useMemo(() => {
@@ -152,6 +154,7 @@ export default function ExtensionsSection() {
             enabled: true,
             timeoutMs: serverData.timeoutSec * 1000,
             requiresApproval: serverData.requiresApproval,
+            toolApprovalOverrides: {},
           }
         : {
             id: crypto.randomUUID(),
@@ -162,6 +165,7 @@ export default function ExtensionsSection() {
             enabled: true,
             timeoutMs: serverData.timeoutSec * 1000,
             requiresApproval: serverData.requiresApproval,
+            toolApprovalOverrides: {},
           };
 
     setMcpServers((prev) => [newServer, ...prev]);
@@ -175,6 +179,7 @@ export default function ExtensionsSection() {
       enabled: true,
       timeoutMs: installed.timeoutSec * 1000,
       requiresApproval: installed.requiresApproval,
+      toolApprovalOverrides: {},
     };
 
     const newServer: McpServerConfig =
@@ -280,8 +285,15 @@ export default function ExtensionsSection() {
     showDeviceExtensions,
     showOnlineExtensions,
     isInstalled: isExtensionInstalled,
+    getServerForExtension: getExtensionServer,
+    getLoadStateForExtension: (extension: McpRegistryExtension) => {
+      const server = getExtensionServer(extension);
+      return server ? mcpServerLoadStates[server.id] : undefined;
+    },
     onInstallClick: handleExtensionInstallClick,
     onUninstallClick: handleExtensionUninstallClick,
+    onEnabledChange: (serverId: string, enabled: boolean) =>
+      updateMcpServerById(serverId, { enabled }),
     getAdvancedContent: renderAdvancedContent,
     getMoreInfoJson: (extension: McpRegistryExtension) => extension.registryEntry,
   };
@@ -394,6 +406,9 @@ export default function ExtensionsSection() {
                         title={server.name || "Custom Extension"}
                         description={server.type === "stdio" ? server.command : server.url}
                         installed
+                        enabled={server.enabled}
+                        loadState={mcpServerLoadStates[server.id]}
+                        onEnabledChange={(enabled) => updateMcpServerById(server.id, { enabled })}
                         onUninstall={() =>
                           linkedExtension
                             ? handleExtensionUninstallClick(linkedExtension)

--- a/src/routes/settings/sections/extensions/mcp-server-approval-settings.tsx
+++ b/src/routes/settings/sections/extensions/mcp-server-approval-settings.tsx
@@ -1,0 +1,118 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import { type McpServerLoadState } from "@/lib/jotai/mcp-atoms";
+
+interface McpServerApprovalSettingsProps {
+  idPrefix: string;
+  enabled: boolean;
+  requiresApproval: boolean;
+  toolApprovalOverrides?: Record<string, boolean>;
+  loadState?: McpServerLoadState;
+  approvalDescription: string;
+  onRequiresApprovalChange: (requiresApproval: boolean) => void;
+  onToolApprovalOverridesChange: (overrides: Record<string, boolean>) => void;
+}
+
+export function McpServerApprovalSettings({
+  idPrefix,
+  enabled,
+  requiresApproval,
+  toolApprovalOverrides,
+  loadState,
+  approvalDescription,
+  onRequiresApprovalChange,
+  onToolApprovalOverridesChange,
+}: McpServerApprovalSettingsProps) {
+  const availableTools = loadState?.toolNames ?? [];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <Label htmlFor={`${idPrefix}-requires-approval`} className="text-sm">
+            Require Approval By Default
+          </Label>
+          <span className="text-muted-foreground text-xs">{approvalDescription}</span>
+        </div>
+        <Switch
+          id={`${idPrefix}-requires-approval`}
+          checked={requiresApproval}
+          onCheckedChange={onRequiresApprovalChange}
+        />
+      </div>
+
+      <Accordion type="single" collapsible className="rounded-md border px-3">
+        <AccordionItem value="tool-approval" className="border-b-0">
+          <AccordionTrigger className="py-3 text-sm">Per-tool approvals</AccordionTrigger>
+          <AccordionContent className="pb-3">
+            <div className="flex flex-col gap-3">
+              {!enabled ? (
+                <span className="text-muted-foreground text-sm">
+                  Enable this server to configure per-tool approvals.
+                </span>
+              ) : loadState?.status === "starting" ||
+                loadState?.status === "connecting" ||
+                loadState?.status === "unknown" ? (
+                <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                  <Spinner className="size-4" />
+                  Tool list will appear after the server finishes loading.
+                </div>
+              ) : loadState?.status === "error" ? (
+                <span className="text-muted-foreground text-sm">
+                  Tools could not be loaded yet. Resolve the server error to configure per-tool
+                  approvals.
+                </span>
+              ) : availableTools.length === 0 ? (
+                <span className="text-muted-foreground text-sm">
+                  This server does not currently expose any tools.
+                </span>
+              ) : (
+                availableTools.map((toolName) => {
+                  const override = toolApprovalOverrides?.[toolName];
+                  const toolRequiresApproval = override ?? requiresApproval;
+
+                  return (
+                    <div key={toolName} className="flex items-center justify-between gap-3">
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate text-sm font-medium">{toolName}</span>
+                        <span className="text-muted-foreground text-xs">
+                          {override === undefined
+                            ? `Using default: ${requiresApproval ? "approval required" : "no approval required"}`
+                            : toolRequiresApproval
+                              ? "Approval required"
+                              : "No approval required"}
+                        </span>
+                      </div>
+                      <Switch
+                        checked={toolRequiresApproval}
+                        onCheckedChange={(checked) => {
+                          const nextOverrides = { ...(toolApprovalOverrides ?? {}) };
+
+                          if (checked === requiresApproval) {
+                            delete nextOverrides[toolName];
+                          } else {
+                            nextOverrides[toolName] = checked;
+                          }
+
+                          onToolApprovalOverridesChange(nextOverrides);
+                        }}
+                        aria-label={`Toggle approval for ${toolName}`}
+                      />
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+}

--- a/src/routes/settings/sections/extensions/mcp-server-config-form.tsx
+++ b/src/routes/settings/sections/extensions/mcp-server-config-form.tsx
@@ -2,6 +2,12 @@ import type { ReactNode } from "react";
 
 import { EnvVarsEditor } from "@/components/a1/input/env-vars-editor";
 import { HttpHeadersEditor } from "@/components/a1/input/http-headers-editor";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -24,6 +30,7 @@ export interface McpServerConfigFormValues {
   headers: Record<string, string>;
   timeoutSec: number;
   requiresApproval: boolean;
+  toolApprovalOverrides?: Record<string, boolean>;
 }
 
 interface McpServerConfigFormProps {
@@ -39,6 +46,7 @@ interface McpServerConfigFormProps {
   approvalDescription?: string;
   stdioSupplement?: ReactNode;
   httpSupplement?: ReactNode;
+  availableTools?: string[];
 }
 
 export function McpServerConfigForm({
@@ -54,6 +62,7 @@ export function McpServerConfigForm({
   approvalDescription = "Ask for confirmation before running tools from this server",
   stdioSupplement,
   httpSupplement,
+  availableTools = [],
 }: McpServerConfigFormProps) {
   const isStdio = values.type === "stdio";
 
@@ -157,7 +166,7 @@ export function McpServerConfigForm({
       <div className="flex items-center justify-between">
         <div className="flex flex-col">
           <Label htmlFor={`${idPrefix}-requires-approval`} className="text-sm">
-            Require Approval
+            Require Approval By Default
           </Label>
           <span className="text-muted-foreground text-xs">{approvalDescription}</span>
         </div>
@@ -167,6 +176,55 @@ export function McpServerConfigForm({
           onCheckedChange={(requiresApproval) => onChange({ requiresApproval })}
         />
       </div>
+
+      {availableTools.length > 0 ? (
+        <Accordion type="single" collapsible className="rounded-md border px-3">
+          <AccordionItem value="tool-approval" className="border-b-0">
+            <AccordionTrigger className="py-3 text-sm">Per-tool approval</AccordionTrigger>
+            <AccordionContent className="pb-3">
+              <div className="flex flex-col gap-3">
+                {availableTools.map((toolName) => {
+                  const override = values.toolApprovalOverrides?.[toolName];
+                  const requiresApproval = override ?? values.requiresApproval;
+
+                  return (
+                    <div key={toolName} className="flex items-center justify-between gap-3">
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate text-sm font-medium">{toolName}</span>
+                        <span className="text-muted-foreground text-xs">
+                          {override === undefined
+                            ? `Using default: ${values.requiresApproval ? "approval required" : "no approval required"}`
+                            : requiresApproval
+                              ? "Approval required"
+                              : "No approval required"}
+                        </span>
+                      </div>
+                      <Switch
+                        checked={requiresApproval}
+                        onCheckedChange={(checked) => {
+                          const nextOverrides = { ...(values.toolApprovalOverrides ?? {}) };
+
+                          if (checked === values.requiresApproval) {
+                            delete nextOverrides[toolName];
+                          } else {
+                            nextOverrides[toolName] = checked;
+                          }
+
+                          onChange({
+                            toolApprovalOverrides:
+                              Object.keys(nextOverrides).length > 0 ? nextOverrides : {},
+                          });
+                        }}
+                        aria-label={`Toggle approval for ${toolName}`}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      ) : null}
     </div>
   );
 }

--- a/src/routes/settings/sections/extensions/mcp-server-config-form.tsx
+++ b/src/routes/settings/sections/extensions/mcp-server-config-form.tsx
@@ -2,12 +2,6 @@ import type { ReactNode } from "react";
 
 import { EnvVarsEditor } from "@/components/a1/input/env-vars-editor";
 import { HttpHeadersEditor } from "@/components/a1/input/http-headers-editor";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -30,7 +24,6 @@ export interface McpServerConfigFormValues {
   headers: Record<string, string>;
   timeoutSec: number;
   requiresApproval: boolean;
-  toolApprovalOverrides?: Record<string, boolean>;
 }
 
 interface McpServerConfigFormProps {
@@ -46,7 +39,7 @@ interface McpServerConfigFormProps {
   approvalDescription?: string;
   stdioSupplement?: ReactNode;
   httpSupplement?: ReactNode;
-  availableTools?: string[];
+  showApprovalControls?: boolean;
 }
 
 export function McpServerConfigForm({
@@ -62,7 +55,7 @@ export function McpServerConfigForm({
   approvalDescription = "Ask for confirmation before running tools from this server",
   stdioSupplement,
   httpSupplement,
-  availableTools = [],
+  showApprovalControls = false,
 }: McpServerConfigFormProps) {
   const isStdio = values.type === "stdio";
 
@@ -163,67 +156,20 @@ export function McpServerConfigForm({
         />
       </div>
 
-      <div className="flex items-center justify-between">
-        <div className="flex flex-col">
-          <Label htmlFor={`${idPrefix}-requires-approval`} className="text-sm">
-            Require Approval By Default
-          </Label>
-          <span className="text-muted-foreground text-xs">{approvalDescription}</span>
+      {showApprovalControls ? (
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <Label htmlFor={`${idPrefix}-requires-approval`} className="text-sm">
+              Require Approval By Default
+            </Label>
+            <span className="text-muted-foreground text-xs">{approvalDescription}</span>
+          </div>
+          <Switch
+            id={`${idPrefix}-requires-approval`}
+            checked={values.requiresApproval}
+            onCheckedChange={(requiresApproval) => onChange({ requiresApproval })}
+          />
         </div>
-        <Switch
-          id={`${idPrefix}-requires-approval`}
-          checked={values.requiresApproval}
-          onCheckedChange={(requiresApproval) => onChange({ requiresApproval })}
-        />
-      </div>
-
-      {availableTools.length > 0 ? (
-        <Accordion type="single" collapsible className="rounded-md border px-3">
-          <AccordionItem value="tool-approval" className="border-b-0">
-            <AccordionTrigger className="py-3 text-sm">Per-tool approval</AccordionTrigger>
-            <AccordionContent className="pb-3">
-              <div className="flex flex-col gap-3">
-                {availableTools.map((toolName) => {
-                  const override = values.toolApprovalOverrides?.[toolName];
-                  const requiresApproval = override ?? values.requiresApproval;
-
-                  return (
-                    <div key={toolName} className="flex items-center justify-between gap-3">
-                      <div className="flex min-w-0 flex-col">
-                        <span className="truncate text-sm font-medium">{toolName}</span>
-                        <span className="text-muted-foreground text-xs">
-                          {override === undefined
-                            ? `Using default: ${values.requiresApproval ? "approval required" : "no approval required"}`
-                            : requiresApproval
-                              ? "Approval required"
-                              : "No approval required"}
-                        </span>
-                      </div>
-                      <Switch
-                        checked={requiresApproval}
-                        onCheckedChange={(checked) => {
-                          const nextOverrides = { ...(values.toolApprovalOverrides ?? {}) };
-
-                          if (checked === values.requiresApproval) {
-                            delete nextOverrides[toolName];
-                          } else {
-                            nextOverrides[toolName] = checked;
-                          }
-
-                          onChange({
-                            toolApprovalOverrides:
-                              Object.keys(nextOverrides).length > 0 ? nextOverrides : {},
-                          });
-                        }}
-                        aria-label={`Toggle approval for ${toolName}`}
-                      />
-                    </div>
-                  );
-                })}
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
       ) : null}
     </div>
   );

--- a/src/routes/settings/sections/extensions/mcp-server-status-utils.ts
+++ b/src/routes/settings/sections/extensions/mcp-server-status-utils.ts
@@ -1,0 +1,25 @@
+import { type McpServerLoadState } from "@/lib/jotai/mcp-atoms";
+
+export function getMcpServerStatusTooltip(state?: McpServerLoadState, disabled?: boolean): string {
+  if (disabled) {
+    return "Disabled";
+  }
+
+  switch (state?.status) {
+    case "loaded":
+      return state.toolCount === 1
+        ? "Loaded successfully with 1 tool"
+        : `Loaded successfully with ${state?.toolCount ?? 0} tools`;
+    case "error":
+      return state.error ? `Error: ${state.error}` : "Error";
+    case "starting":
+      return "Starting";
+    case "connecting":
+      return "Connecting";
+    case "disabled":
+      return "Disabled";
+    case "unknown":
+    default:
+      return "Unknown";
+  }
+}

--- a/src/routes/settings/sections/extensions/mcp-server-status.tsx
+++ b/src/routes/settings/sections/extensions/mcp-server-status.tsx
@@ -1,0 +1,83 @@
+import { IconCircleCheck, IconCircleX, IconInfoCircle } from "@tabler/icons-react";
+
+import { Spinner } from "@/components/ui/spinner";
+import { type McpServerLoadState } from "@/lib/jotai/mcp-atoms";
+import { cn } from "@/lib/utils";
+
+interface McpServerStatusProps {
+  state?: McpServerLoadState;
+  disabled?: boolean;
+  compact?: boolean;
+}
+
+function getStatusLabel(status: McpServerLoadState["status"] | undefined): string {
+  switch (status) {
+    case "disabled":
+      return "Disabled";
+    case "starting":
+      return "Starting";
+    case "connecting":
+      return "Connecting";
+    case "loaded":
+      return "Loaded";
+    case "error":
+      return "Error";
+    case "unknown":
+    default:
+      return "Unknown";
+  }
+}
+
+export function McpServerStatus({
+  state,
+  disabled = false,
+  compact = false,
+}: McpServerStatusProps) {
+  const status = disabled ? "disabled" : (state?.status ?? "unknown");
+  const label = getStatusLabel(status);
+
+  if (compact) {
+    if (status === "starting" || status === "connecting") {
+      return <Spinner className="text-muted-foreground size-3" />;
+    }
+
+    return (
+      <div
+        className={cn(
+          "size-2 rounded-full",
+          status === "loaded" && "bg-green-500",
+          status === "error" && "bg-red-500",
+          (status === "unknown" || status === "disabled") && "bg-yellow-500",
+        )}
+      />
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between rounded-md border p-3">
+      <div className="flex items-center gap-2">
+        {status === "starting" || status === "connecting" ? (
+          <Spinner className="text-foreground" data-icon="inline-start" />
+        ) : status === "loaded" ? (
+          <IconCircleCheck className="text-foreground size-5" />
+        ) : status === "error" ? (
+          <IconCircleX className="text-foreground size-5" />
+        ) : (
+          <IconInfoCircle className="text-foreground size-5" />
+        )}
+        <div className="flex flex-col gap-0.5">
+          <span className="text-foreground text-sm">{label}</span>
+          {status === "loaded" ? (
+            <span className="text-muted-foreground text-xs">
+              {state?.toolCount === 1
+                ? "1 tool available"
+                : `${state?.toolCount ?? 0} tools available`}
+            </span>
+          ) : state?.error ? (
+            <span className="text-muted-foreground line-clamp-2 text-xs">{state.error}</span>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/settings/sections/extensions/mcp-server-status.tsx
+++ b/src/routes/settings/sections/extensions/mcp-server-status.tsx
@@ -1,6 +1,5 @@
-import { IconCircleCheck, IconCircleX, IconInfoCircle } from "@tabler/icons-react";
-
 import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
 import { type McpServerLoadState } from "@/lib/jotai/mcp-atoms";
 import { cn } from "@/lib/utils";
 
@@ -8,23 +7,43 @@ interface McpServerStatusProps {
   state?: McpServerLoadState;
   disabled?: boolean;
   compact?: boolean;
+  switchId?: string;
+  onEnabledChange?: (enabled: boolean) => void;
 }
 
 function getStatusLabel(status: McpServerLoadState["status"] | undefined): string {
   switch (status) {
     case "disabled":
       return "Disabled";
-    case "starting":
-      return "Starting";
-    case "connecting":
-      return "Connecting";
     case "loaded":
-      return "Loaded";
+    case "starting":
+    case "connecting":
+    case "unknown":
+      return "Enabled";
     case "error":
       return "Error";
-    case "unknown":
     default:
       return "Unknown";
+  }
+}
+
+function getStatusDescription(state?: McpServerLoadState, disabled?: boolean): string {
+  if (disabled) {
+    return "Toggle the switch to enable this server";
+  }
+
+  switch (state?.status) {
+    case "loaded":
+      return state.toolCount === 1 ? "1 tool available" : `${state.toolCount} tools available`;
+    case "starting":
+      return "Starting server";
+    case "connecting":
+      return "Connecting to server";
+    case "error":
+      return state.error ?? "Unable to load tools";
+    case "unknown":
+    default:
+      return "Waiting for server to load";
   }
 }
 
@@ -32,6 +51,8 @@ export function McpServerStatus({
   state,
   disabled = false,
   compact = false,
+  switchId,
+  onEnabledChange,
 }: McpServerStatusProps) {
   const status = disabled ? "disabled" : (state?.status ?? "unknown");
   const label = getStatusLabel(status);
@@ -54,30 +75,23 @@ export function McpServerStatus({
   }
 
   return (
-    <div className="flex items-center justify-between rounded-md border p-3">
+    <div className="flex items-center justify-between gap-3">
       <div className="flex items-center gap-2">
-        {status === "starting" || status === "connecting" ? (
-          <Spinner className="text-foreground" data-icon="inline-start" />
-        ) : status === "loaded" ? (
-          <IconCircleCheck className="text-foreground size-5" />
-        ) : status === "error" ? (
-          <IconCircleX className="text-foreground size-5" />
-        ) : (
-          <IconInfoCircle className="text-foreground size-5" />
-        )}
         <div className="flex flex-col gap-0.5">
           <span className="text-foreground text-sm">{label}</span>
-          {status === "loaded" ? (
-            <span className="text-muted-foreground text-xs">
-              {state?.toolCount === 1
-                ? "1 tool available"
-                : `${state?.toolCount ?? 0} tools available`}
-            </span>
-          ) : state?.error ? (
-            <span className="text-muted-foreground line-clamp-2 text-xs">{state.error}</span>
-          ) : null}
+          <span className="text-muted-foreground line-clamp-2 text-xs">
+            {getStatusDescription(state, disabled)}
+          </span>
         </div>
       </div>
+      {onEnabledChange ? (
+        <Switch
+          id={switchId}
+          checked={!disabled}
+          onCheckedChange={onEnabledChange}
+          aria-label="Toggle extension"
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
WIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Configure per-tool approval requirements that can override server defaults.
  - Real-time MCP server status indicators with connection states, tool counts, and error messages.
  - Per-server approval settings UI with per-tool toggle controls and contextual guidance.
  - Toggle installed extensions on/off directly from the settings list and see associated server load state.
  - Improved tool loading feedback during startup, chunked loads, and overall load failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->