### PR TITLE
fix: managed update detection

### DIFF
--- a/distribution/aur/PKGBUILD
+++ b/distribution/aur/PKGBUILD
@@ -26,6 +26,5 @@ sha256sums_x86_64=('SKIP')
 
 package() {
   tar -xf data.tar.gz -C "${pkgdir}"
-  install -dm755 "${pkgdir}/usr/lib/agent-one"
   install -Dm644 /dev/null "${pkgdir}/usr/lib/agent-one/updates-managed-externally"
 }

--- a/distribution/aur/PKGBUILD
+++ b/distribution/aur/PKGBUILD
@@ -26,4 +26,6 @@ sha256sums_x86_64=('SKIP')
 
 package() {
   tar -xf data.tar.gz -C "${pkgdir}"
+  install -dm755 "${pkgdir}/usr/lib/agent-one"
+  install -Dm644 /dev/null "${pkgdir}/usr/lib/agent-one/updates-managed-externally"
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -146,6 +146,7 @@ pub fn run() {
                 tauri::generate_handler![
                     tools::get_url_content,
                     tools::web_search,
+                    utils::is_update_managed_externally,
                     utils::webview_html_callback,
                     utils::list_webviews,
                     utils::force_close_webview,
@@ -165,6 +166,7 @@ pub fn run() {
                 tauri::generate_handler![
                     tools::get_url_content,
                     tools::web_search,
+                    utils::is_update_managed_externally,
                     keyring::storage_get_item,
                     keyring::storage_set_item,
                     keyring::storage_remove_item,

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,5 +1,9 @@
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub mod headless_webview;
 
+pub mod update_management;
+
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use headless_webview::*;
+
+pub use update_management::*;

--- a/src-tauri/src/utils/update_management.rs
+++ b/src-tauri/src/utils/update_management.rs
@@ -2,11 +2,13 @@ use std::{env, path::Path};
 
 const EXTERNAL_UPDATE_MARKER_PATH: &str = "/usr/lib/agent-one/updates-managed-externally";
 const EXTERNAL_UPDATE_ENV_VARS: &[&str] = &["SNAP", "SNAP_NAME", "FLATPAK_ID"];
+const FLATPAK_INFO_PATH: &str = "/.flatpak-info";
 
 #[tauri::command]
 pub fn is_update_managed_externally() -> bool {
     EXTERNAL_UPDATE_ENV_VARS
         .iter()
         .any(|name| env::var_os(name).is_some())
+        || Path::new(FLATPAK_INFO_PATH).exists()
         || Path::new(EXTERNAL_UPDATE_MARKER_PATH).exists()
 }

--- a/src-tauri/src/utils/update_management.rs
+++ b/src-tauri/src/utils/update_management.rs
@@ -1,0 +1,12 @@
+use std::{env, path::Path};
+
+const EXTERNAL_UPDATE_MARKER_PATH: &str = "/usr/lib/agent-one/updates-managed-externally";
+const EXTERNAL_UPDATE_ENV_VARS: &[&str] = &["SNAP", "SNAP_NAME", "FLATPAK_ID"];
+
+#[tauri::command]
+pub fn is_update_managed_externally() -> bool {
+    EXTERNAL_UPDATE_ENV_VARS
+        .iter()
+        .any(|name| env::var_os(name).is_some())
+        || Path::new(EXTERNAL_UPDATE_MARKER_PATH).exists()
+}

--- a/src/contexts/use-update/update-context.tsx
+++ b/src/contexts/use-update/update-context.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
 import { useAtom } from "jotai";
@@ -26,6 +27,19 @@ export const UpdateProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     try {
       setUpdateStatus("checking");
 
+      let managedExternally = false;
+      try {
+        managedExternally = await invoke<boolean>("is_update_managed_externally");
+      } catch (error) {
+        logger.error("Failed to determine whether updates are externally managed.", error);
+      }
+
+      if (managedExternally) {
+        setUpdateStatus("managed-externally");
+        logger.verbose("Updates are managed externally. Skipping built-in updater.");
+        return;
+      }
+
       const update = await check();
       logger.verbose(`Update check completed. Update found: ${!!update}.`);
 
@@ -51,6 +65,19 @@ export const UpdateProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     try {
       setUpdateStatus("downloading");
       setUpdateProgress(0);
+
+      let managedExternally = false;
+      try {
+        managedExternally = await invoke<boolean>("is_update_managed_externally");
+      } catch (error) {
+        logger.error("Failed to determine whether updates are externally managed.", error);
+      }
+
+      if (managedExternally) {
+        setUpdateStatus("managed-externally");
+        logger.verbose("Updates are managed externally. Skipping built-in install.");
+        return;
+      }
 
       const update = await check();
       if (!update) {
@@ -95,8 +122,7 @@ export const UpdateProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       await checkForUpdates();
     };
     void startCheck();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [checkForUpdates]);
 
   const dialogOpen = updateStatus === "available" && !dialogDismissed;
 

--- a/src/contexts/use-update/update-contexts.ts
+++ b/src/contexts/use-update/update-contexts.ts
@@ -3,6 +3,7 @@ import { createContext } from "react";
 export type UpdateStatus =
   | "idle"
   | "checking"
+  | "managed-externally"
   | "up-to-date"
   | "available"
   | "downloading"

--- a/src/routes/settings/sections/about.tsx
+++ b/src/routes/settings/sections/about.tsx
@@ -36,6 +36,12 @@ export default function AboutSection() {
           title: "Checking for updates...",
           description: "Please wait while we check for the latest version",
         };
+      case "managed-externally":
+        return {
+          icon: <IconShieldCheck className="text-muted-foreground size-5" />,
+          title: "Automatic updates disabled",
+          description: "Update AgentOne through your software manager instead",
+        };
       case "up-to-date":
         return {
           icon: <IconCircleCheck className="size-5" />,
@@ -86,6 +92,8 @@ export default function AboutSection() {
             Checking...
           </Button>
         );
+      case "managed-externally":
+        return null;
       case "available":
         return (
           <Button onClick={downloadAndInstallUpdate} size="sm">


### PR DESCRIPTION
Fixes #137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added detection for externally-managed updates. When the app identifies that updates are handled by an external package manager, the built-in updater is disabled and users receive guidance to update through their software manager instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->