### PR TITLE
feat: add ability to skip and stop commands

### DIFF
--- a/src/components/a1/messages/tools/tool-executeCommand.tsx
+++ b/src/components/a1/messages/tools/tool-executeCommand.tsx
@@ -281,6 +281,7 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
     case "output-available": {
       const outputFromPart = (part.output as ExecuteCommandOutput | undefined) ?? EMPTY_OUTPUT;
       const isPreliminary = (part as { preliminary?: boolean }).preliminary === true;
+      const showSpinnerIcon = isPreliminary || liveState?.status === "skipped-running";
       const output: ExecuteCommandOutput = liveState
         ? {
             stdout: liveState.stdout,
@@ -313,7 +314,7 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
             <AccordionTrigger
               icon={
                 <div className="relative">
-                  {isPreliminary || liveState?.status === "skipped-running" ? (
+                  {showSpinnerIcon ? (
                     <Spinner className="text-foreground absolute inset-0 size-4 shrink-0" />
                   ) : (
                     <IconTerminal2
@@ -323,7 +324,7 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
                       )}
                     />
                   )}
-                  {!isPreliminary && (
+                  {!showSpinnerIcon && (
                     <IconChevronDown
                       className={cn(
                         "text-foreground absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/exec-accordion:scale-100 group-hover/exec-accordion:opacity-100",

--- a/src/components/a1/messages/tools/tool-executeCommand.tsx
+++ b/src/components/a1/messages/tools/tool-executeCommand.tsx
@@ -19,6 +19,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/native/accordion";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useChatFunctions } from "@/contexts/use-chat/chat-hooks";
 import {
   getExecuteCommandLiveState,
@@ -109,18 +110,40 @@ const TerminalDisplay = ({
 
 const LongRunningControls = ({ callId, showSkip }: { callId: string; showSkip: boolean }) => {
   return (
-    <div className="flex items-center gap-1">
-      <Button size="xs" variant="outline" onClick={() => stopExecuteCommand(callId)}>
-        <IconPlayerStop data-icon="inline-start" />
-        Stop
-      </Button>
-      {showSkip && (
-        <Button size="xs" variant="outline" onClick={() => skipExecuteCommand(callId)}>
-          <IconPlayerSkipForward data-icon="inline-start" />
-          Skip
-        </Button>
-      )}
-    </div>
+    <TooltipProvider>
+      <div className="flex items-center gap-0.5">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon-xs"
+              variant="destructive"
+              className="size-5 shrink-0"
+              onClick={() => stopExecuteCommand(callId)}
+            >
+              <IconPlayerStop className="size-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">Stop command</TooltipContent>
+        </Tooltip>
+        {showSkip && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon-xs"
+                variant="secondary"
+                className="size-5 shrink-0"
+                onClick={() => skipExecuteCommand(callId)}
+              >
+                <IconPlayerSkipForward className="size-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              Skip command (leave it running in the background)
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </TooltipProvider>
   );
 };
 
@@ -237,14 +260,12 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
       return (
         <div
           key={callId}
-          className="text-foreground flex max-w-2xl flex-col gap-1 text-sm font-bold"
+          className="text-foreground flex max-w-2xl flex-row items-center gap-1 text-sm font-bold"
         >
-          <div className="text-foreground flex flex-row items-center gap-1 text-sm font-bold">
-            <Spinner className="text-foreground size-4 shrink-0" />
-            <span className="max-w-2xl truncate">
-              Running <code className="text-xs">{truncatedCommand}</code>...
-            </span>
-          </div>
+          <Spinner className="text-foreground size-4 shrink-0" />
+          <span className="truncate">
+            Running <code className="text-xs">{truncatedCommand}</code>...
+          </span>
           {showLongRunningStop && (
             <LongRunningControls callId={callId} showSkip={showLongRunningSkip} />
           )}
@@ -331,12 +352,12 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
                             ? ` (exit code ${output.exitCode})`
                             : ""}
               </span>
+              {showLongRunningStop && (
+                <LongRunningControls callId={callId} showSkip={showLongRunningSkip} />
+              )}
             </AccordionTrigger>
             <AccordionContent className="p-0 pt-2">
               <div className="flex flex-col gap-2">
-                {showLongRunningStop && (
-                  <LongRunningControls callId={callId} showSkip={showLongRunningSkip} />
-                )}
                 <TerminalDisplay command={command} output={output} />
               </div>
             </AccordionContent>

--- a/src/components/a1/messages/tools/tool-executeCommand.tsx
+++ b/src/components/a1/messages/tools/tool-executeCommand.tsx
@@ -118,9 +118,12 @@ const LongRunningControls = ({ callId, showSkip }: { callId: string; showSkip: b
               size="icon-xs"
               variant="destructive"
               className="size-5 shrink-0"
-              onClick={() => stopExecuteCommand(callId)}
+              onClick={(e) => {
+                e.stopPropagation();
+                stopExecuteCommand(callId);
+              }}
             >
-              <IconPlayerStop className="size-3" />
+              <IconPlayerStop />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top">Stop command</TooltipContent>
@@ -132,9 +135,12 @@ const LongRunningControls = ({ callId, showSkip }: { callId: string; showSkip: b
                 size="icon-xs"
                 variant="secondary"
                 className="size-5 shrink-0"
-                onClick={() => skipExecuteCommand(callId)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  skipExecuteCommand(callId);
+                }}
               >
-                <IconPlayerSkipForward className="size-3" />
+                <IconPlayerSkipForward />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="top">
@@ -307,7 +313,7 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
             <AccordionTrigger
               icon={
                 <div className="relative">
-                  {isPreliminary ? (
+                  {isPreliminary || liveState?.status === "skipped-running" ? (
                     <Spinner className="text-foreground absolute inset-0 size-4 shrink-0" />
                   ) : (
                     <IconTerminal2
@@ -339,7 +345,7 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
                     : "Ran "}
                 <code className="text-xs">{truncatedCommand}</code>
                 {liveState?.status === "skipped-running"
-                  ? " (still running in background)"
+                  ? " (backgrounded)"
                   : isPreliminary
                     ? ""
                     : output.timedOut

--- a/src/components/a1/messages/tools/tool-executeCommand.tsx
+++ b/src/components/a1/messages/tools/tool-executeCommand.tsx
@@ -2,12 +2,14 @@ import {
   IconChevronDown,
   IconCircleCheck,
   IconCircleX,
+  IconPlayerSkipForward,
+  IconPlayerStop,
   IconTerminal2,
   IconX,
 } from "@tabler/icons-react";
 import type { ToolUIPart } from "ai";
 import { AnsiHtml } from "fancy-ansi/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,7 +20,13 @@ import {
 } from "@/components/ui/native/accordion";
 import { Spinner } from "@/components/ui/spinner";
 import { useChatFunctions } from "@/contexts/use-chat/chat-hooks";
-import type { ExecuteCommandOutput } from "@/lib/ai/tools/executeCommand";
+import {
+  getExecuteCommandLiveState,
+  skipExecuteCommand,
+  stopExecuteCommand,
+  subscribeExecuteCommandLiveState,
+  type ExecuteCommandOutput,
+} from "@/lib/ai/tools/executeCommand";
 import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -99,12 +107,64 @@ const TerminalDisplay = ({
   );
 };
 
+const LongRunningControls = ({ callId, showSkip }: { callId: string; showSkip: boolean }) => {
+  return (
+    <div className="flex items-center gap-1">
+      <Button size="xs" variant="outline" onClick={() => stopExecuteCommand(callId)}>
+        <IconPlayerStop data-icon="inline-start" />
+        Stop
+      </Button>
+      {showSkip && (
+        <Button size="xs" variant="outline" onClick={() => skipExecuteCommand(callId)}>
+          <IconPlayerSkipForward data-icon="inline-start" />
+          Skip
+        </Button>
+      )}
+    </div>
+  );
+};
+
 export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartProps) => {
   const callId = part.toolCallId;
   const input = part.input as ExecuteCommandInput;
   const { addToolApprovalResponse } = useChatFunctions();
   const [isMainAccordionOpen, setIsMainAccordionOpen] = useState<boolean | undefined>();
   const [isErrorAccordionOpen, setIsErrorAccordionOpen] = useState<boolean | undefined>();
+  const [longRunningNow, setLongRunningNow] = useState(() => Date.now());
+
+  const liveState = useSyncExternalStore(
+    (listener) => subscribeExecuteCommandLiveState(callId, listener),
+    () => getExecuteCommandLiveState(callId),
+    () => getExecuteCommandLiveState(callId),
+  );
+
+  useEffect(() => {
+    if (!liveState || liveState.status === "completed") {
+      return;
+    }
+
+    const elapsed = Date.now() - liveState.startedAt;
+    if (elapsed >= 1000) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setLongRunningNow(Date.now());
+    }, 1000 - elapsed);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [liveState]);
+
+  const showLongRunningStop = Boolean(
+    liveState &&
+    liveState.status !== "completed" &&
+    !liveState.timedOut &&
+    longRunningNow - liveState.startedAt >= 1000,
+  );
+  const showLongRunningSkip =
+    showLongRunningStop && liveState?.status === "running" && !liveState?.skipRequested;
 
   const command = input?.command || "unknown command";
   const truncatedCommand = command.length > 80 ? command.slice(0, 80) + "…" : command;
@@ -177,18 +237,36 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
       return (
         <div
           key={callId}
-          className="text-foreground flex flex-row items-center gap-1 text-sm font-bold"
+          className="text-foreground flex max-w-2xl flex-col gap-1 text-sm font-bold"
         >
-          <Spinner className="text-foreground size-4 shrink-0" />
-          <span className="max-w-2xl truncate">
-            Running <code className="text-xs">{truncatedCommand}</code>...
-          </span>
+          <div className="text-foreground flex flex-row items-center gap-1 text-sm font-bold">
+            <Spinner className="text-foreground size-4 shrink-0" />
+            <span className="max-w-2xl truncate">
+              Running <code className="text-xs">{truncatedCommand}</code>...
+            </span>
+          </div>
+          {showLongRunningStop && (
+            <LongRunningControls callId={callId} showSkip={showLongRunningSkip} />
+          )}
         </div>
       );
 
     case "output-available": {
-      const output = (part.output as ExecuteCommandOutput | undefined) ?? EMPTY_OUTPUT;
+      const outputFromPart = (part.output as ExecuteCommandOutput | undefined) ?? EMPTY_OUTPUT;
       const isPreliminary = (part as { preliminary?: boolean }).preliminary === true;
+      const output: ExecuteCommandOutput = liveState
+        ? {
+            stdout: liveState.stdout,
+            stderr: liveState.stderr,
+            exitCode: outputFromPart.exitCode ?? liveState.exitCode,
+            signal: outputFromPart.signal ?? liveState.signal,
+            timedOut: outputFromPart.timedOut || liveState.timedOut,
+            skipped: outputFromPart.skipped ?? liveState.skipRequested,
+            stopped:
+              outputFromPart.stopped ??
+              (liveState.stopRequested && !liveState.skipRequested ? true : undefined),
+          }
+        : outputFromPart;
 
       return (
         <Accordion
@@ -233,19 +311,34 @@ export const MessagePartToolExecuteCommand = ({ part }: ExecuteCommandToolPartPr
               className="justify-start gap-1 p-0 font-bold hover:no-underline"
             >
               <span className="max-w-2xl truncate">
-                {isPreliminary ? "Running " : "Ran "}
+                {liveState?.status === "skipped-running"
+                  ? "Skipped "
+                  : isPreliminary
+                    ? "Running "
+                    : "Ran "}
                 <code className="text-xs">{truncatedCommand}</code>
-                {isPreliminary
-                  ? ""
-                  : output.timedOut
-                    ? " (timed out)"
-                    : output.exitCode && output.exitCode !== 0
-                      ? ` (exit code ${output.exitCode})`
-                      : ""}
+                {liveState?.status === "skipped-running"
+                  ? " (still running in background)"
+                  : isPreliminary
+                    ? ""
+                    : output.timedOut
+                      ? " (timed out)"
+                      : output.stopped
+                        ? " (stopped)"
+                        : output.skipped
+                          ? " (skipped)"
+                          : output.exitCode && output.exitCode !== 0
+                            ? ` (exit code ${output.exitCode})`
+                            : ""}
               </span>
             </AccordionTrigger>
             <AccordionContent className="p-0 pt-2">
-              <TerminalDisplay command={command} output={output} />
+              <div className="flex flex-col gap-2">
+                {showLongRunningStop && (
+                  <LongRunningControls callId={callId} showSkip={showLongRunningSkip} />
+                )}
+                <TerminalDisplay command={command} output={output} />
+              </div>
             </AccordionContent>
           </AccordionItem>
         </Accordion>

--- a/src/lib/ai/tools/executeCommand.ts
+++ b/src/lib/ai/tools/executeCommand.ts
@@ -290,7 +290,7 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
 
       const finalLiveState = getLiveState(toolCallId);
       if (finalLiveState?.stopRequested || finalLiveState?.skipRequested) {
-        return {
+        yield {
           stdout,
           stderr,
           exitCode: null,
@@ -299,6 +299,7 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
           skipped: finalLiveState.skipRequested,
           stopped: finalLiveState.stopRequested,
         } as ExecuteCommandOutput;
+        return;
       }
 
       await result.catch(() => {});
@@ -309,7 +310,7 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
         stderrLen: stderr.length,
       });
 
-      return {
+      yield {
         stdout,
         stderr,
         exitCode,

--- a/src/lib/ai/tools/executeCommand.ts
+++ b/src/lib/ai/tools/executeCommand.ts
@@ -119,7 +119,8 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
       timeoutMs: z
         .number()
         .optional()
-        .describe("Optional timeout in milliseconds (default: 120000)"),
+        .default(config.defaultTimeoutMs)
+        .describe("Optional timeout in milliseconds"),
     }),
     execute: async function* (input, { abortSignal, toolCallId }) {
       logger.verbose("Executing executeCommand tool with input:", input);

--- a/src/lib/ai/tools/executeCommand.ts
+++ b/src/lib/ai/tools/executeCommand.ts
@@ -14,7 +14,100 @@ export interface ExecuteCommandOutput {
   exitCode: number | null;
   signal: number | null;
   timedOut: boolean;
+  skipped?: boolean;
+  stopped?: boolean;
 }
+
+export type ExecuteCommandLiveStatus = "running" | "skipped-running" | "stopping" | "completed";
+
+export interface ExecuteCommandLiveState {
+  toolCallId: string;
+  startedAt: number;
+  endedAt: number | null;
+  status: ExecuteCommandLiveStatus;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: number | null;
+  timedOut: boolean;
+  skipRequested: boolean;
+  stopRequested: boolean;
+}
+
+const executeCommandLiveStateMap = new Map<string, ExecuteCommandLiveState>();
+const executeCommandListenersMap = new Map<string, Set<() => void>>();
+const executeCommandKillMap = new Map<string, () => Promise<void>>();
+const executeCommandWakeMap = new Map<string, () => void>();
+
+const getLiveState = (toolCallId: string) => executeCommandLiveStateMap.get(toolCallId);
+
+const emitLiveState = (toolCallId: string) => {
+  const listeners = executeCommandListenersMap.get(toolCallId);
+  if (!listeners) return;
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+const updateLiveState = (
+  toolCallId: string,
+  updater: (state: ExecuteCommandLiveState) => ExecuteCommandLiveState,
+) => {
+  const current = getLiveState(toolCallId);
+  if (!current) return;
+  executeCommandLiveStateMap.set(toolCallId, updater(current));
+  emitLiveState(toolCallId);
+};
+
+export const getExecuteCommandLiveState = (toolCallId: string) => getLiveState(toolCallId);
+
+export const subscribeExecuteCommandLiveState = (toolCallId: string, listener: () => void) => {
+  const listeners = executeCommandListenersMap.get(toolCallId) ?? new Set<() => void>();
+  listeners.add(listener);
+  executeCommandListenersMap.set(toolCallId, listeners);
+
+  return () => {
+    const currentListeners = executeCommandListenersMap.get(toolCallId);
+    if (!currentListeners) return;
+    currentListeners.delete(listener);
+    if (currentListeners.size === 0) {
+      executeCommandListenersMap.delete(toolCallId);
+    }
+  };
+};
+
+export const skipExecuteCommand = (toolCallId: string) => {
+  updateLiveState(toolCallId, (state) => {
+    if (state.status !== "running") {
+      return state;
+    }
+    return {
+      ...state,
+      status: "skipped-running",
+      skipRequested: true,
+    };
+  });
+  executeCommandWakeMap.get(toolCallId)?.();
+};
+
+export const stopExecuteCommand = (toolCallId: string) => {
+  updateLiveState(toolCallId, (state) => {
+    if (state.status === "completed") {
+      return state;
+    }
+    return {
+      ...state,
+      status: "stopping",
+      stopRequested: true,
+    };
+  });
+
+  const kill = executeCommandKillMap.get(toolCallId);
+  if (kill) {
+    void kill();
+  }
+  executeCommandWakeMap.get(toolCallId)?.();
+};
 
 export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
   tool({
@@ -28,12 +121,28 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
         .optional()
         .describe("Optional timeout in milliseconds (default: 120000)"),
     }),
-    execute: async function* (input, { abortSignal }) {
+    execute: async function* (input, { abortSignal, toolCallId }) {
       logger.verbose("Executing executeCommand tool with input:", input);
 
       abortSignal?.throwIfAborted();
 
       const timeoutMs = input.timeoutMs ?? config.defaultTimeoutMs;
+
+      const startedAt = Date.now();
+      executeCommandLiveStateMap.set(toolCallId, {
+        toolCallId,
+        startedAt,
+        endedAt: null,
+        status: "running",
+        stdout: "",
+        stderr: "",
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        skipRequested: false,
+        stopRequested: false,
+      });
+      emitLiveState(toolCallId);
 
       let stdout = "";
       let stderr = "";
@@ -75,13 +184,17 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
         signal: combinedSignal,
         onStdout: (data) => {
           stdout += data;
+          updateLiveState(toolCallId, (state) => ({ ...state, stdout }));
           push({ type: "stdout", data });
         },
         onStderr: (data) => {
           stderr += data;
+          updateLiveState(toolCallId, (state) => ({ ...state, stderr }));
           push({ type: "stderr", data });
         },
       });
+
+      executeCommandKillMap.set(toolCallId, () => handle.kill());
 
       let done = false;
       let exitCode: number | null = null;
@@ -89,6 +202,11 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
 
       const timeoutId = setTimeout(() => {
         timedOut = true;
+        updateLiveState(toolCallId, (state) => ({
+          ...state,
+          timedOut: true,
+          status: state.status === "completed" ? state.status : "stopping",
+        }));
         void handle.kill();
       }, timeoutMs);
 
@@ -100,6 +218,18 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
         .catch(() => {})
         .finally(() => {
           done = true;
+          const endedAt = Date.now();
+          updateLiveState(toolCallId, (state) => ({
+            ...state,
+            endedAt,
+            status: "completed",
+            exitCode,
+            signal,
+            timedOut,
+          }));
+          clearTimeout(timeoutId);
+          executeCommandKillMap.delete(toolCallId);
+          executeCommandWakeMap.delete(toolCallId);
           push({ type: "done" });
         });
 
@@ -108,54 +238,83 @@ export const createExecuteCommandTool = (config: ExecuteCommandToolConfig) =>
           resolveWait = resolve;
         });
 
-      try {
-        while (!done || queue.length > 0) {
+      executeCommandWakeMap.set(toolCallId, () => {
+        resolveWait?.();
+        resolveWait = null;
+      });
+
+      while (!done || queue.length > 0) {
+        if (combinedSignal.aborted) {
+          throw createAbortError();
+        }
+
+        const liveState = getLiveState(toolCallId);
+        if (liveState?.stopRequested || liveState?.skipRequested) {
+          break;
+        }
+
+        if (queue.length === 0) {
+          await raceWithAbort(waitForNext(), abortSignal);
+        }
+
+        while (queue.length > 0) {
           if (combinedSignal.aborted) {
             throw createAbortError();
           }
 
-          if (queue.length === 0) {
-            await raceWithAbort(waitForNext(), abortSignal);
+          const currentLiveState = getLiveState(toolCallId);
+          if (currentLiveState?.stopRequested || currentLiveState?.skipRequested) {
+            break;
           }
 
-          while (queue.length > 0) {
-            if (combinedSignal.aborted) {
-              throw createAbortError();
-            }
-
-            const item = queue.shift()!;
-            if (item.type === "done") {
-              done = true;
-              continue;
-            }
-
-            yield {
-              stdout,
-              stderr,
-              exitCode: null,
-              signal: null,
-              timedOut: false,
-            } as ExecuteCommandOutput;
+          const item = queue.shift()!;
+          if (item.type === "done") {
+            done = true;
+            continue;
           }
+
+          yield {
+            stdout,
+            stderr,
+            exitCode: null,
+            signal: null,
+            timedOut: false,
+          } as ExecuteCommandOutput;
         }
 
-        await result.catch(() => {});
+        const updatedLiveState = getLiveState(toolCallId);
+        if (updatedLiveState?.stopRequested || updatedLiveState?.skipRequested) {
+          break;
+        }
+      }
 
-        logger.verbose("Command executed:", {
-          exitCode,
-          stdoutLen: stdout.length,
-          stderrLen: stderr.length,
-        });
-
+      const finalLiveState = getLiveState(toolCallId);
+      if (finalLiveState?.stopRequested || finalLiveState?.skipRequested) {
         return {
           stdout,
           stderr,
-          exitCode,
-          signal,
+          exitCode: null,
+          signal: null,
           timedOut,
+          skipped: finalLiveState.skipRequested,
+          stopped: finalLiveState.stopRequested,
         } as ExecuteCommandOutput;
-      } finally {
-        clearTimeout(timeoutId);
       }
+
+      await result.catch(() => {});
+
+      logger.verbose("Command executed:", {
+        exitCode,
+        stdoutLen: stdout.length,
+        stderrLen: stderr.length,
+      });
+
+      return {
+        stdout,
+        stderr,
+        exitCode,
+        signal,
+        timedOut,
+      } as ExecuteCommandOutput;
     },
   });


### PR DESCRIPTION
Closes #144.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop and Skip controls for running command executions (Skip shown only when applicable).
  * Live per-call execution status with updated status labels (running, stopping, skipped-running, completed).
  * Terminal output merges live updates with static output and shows stop/skip/timed-out indicators.
  * Long-running controls appear after one second and are available in both the running row and accordion trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->