### PR TITLE
feat: settings tools

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -148,3 +148,14 @@ ROUTING_RUN
 Opencode
 opencode
 OPENCODE
+pageid
+Inspectable
+inspectable
+srsearch
+srlimit
+exintro
+explaintext
+pllimit
+plnamespace
+cllimit
+maxresults

--- a/src/components/a1/messages/tool-handler.tsx
+++ b/src/components/a1/messages/tool-handler.tsx
@@ -11,9 +11,12 @@ import { MessagePartToolDateTime } from "./tools/tool-dateTime";
 import { MessagePartToolDeleteFile } from "./tools/tool-deleteFile";
 import { MessagePartToolEditFile } from "./tools/tool-editFile";
 import { MessagePartToolExecuteCommand } from "./tools/tool-executeCommand";
+import { MessagePartToolGetSetting } from "./tools/tool-getSetting";
 import { MessagePartToolGetUrlContent } from "./tools/tool-getUrlContent";
+import { MessagePartToolListSettings } from "./tools/tool-listSettings";
 import { MessagePartToolMemory } from "./tools/tool-memory";
 import { MessagePartToolSubAgent } from "./tools/tool-subAgent";
+import { MessagePartToolUpdateSetting } from "./tools/tool-updateSetting";
 import { MessagePartToolViewFile } from "./tools/tool-viewFile";
 import { MessagePartToolWaitNumberMilliseconds } from "./tools/tool-waitNumberMilliseconds";
 import { MessagePartToolWebSearch } from "./tools/tool-webSearch";
@@ -59,6 +62,12 @@ export const MessageToolHandler = memo(
         return <MessagePartToolExecuteCommand part={part} />;
       case "tool-subAgent":
         return <MessagePartToolSubAgent part={part} />;
+      case "tool-listSettings":
+        return <MessagePartToolListSettings part={part} />;
+      case "tool-getSetting":
+        return <MessagePartToolGetSetting part={part} />;
+      case "tool-updateSetting":
+        return <MessagePartToolUpdateSetting part={part} />;
       default:
         return <MessagePartToolCall part={part as ToolUIPart} />;
     }

--- a/src/components/a1/messages/tools/tool-getSetting.tsx
+++ b/src/components/a1/messages/tools/tool-getSetting.tsx
@@ -1,41 +1,19 @@
-import {
-  IconSettings,
-  IconCircleX,
-  IconX,
-  IconCircleCheck,
-  IconChevronDown,
-} from "@tabler/icons-react";
+import { IconSettings, IconCircleX, IconX, IconCircleCheck } from "@tabler/icons-react";
 import type { ToolUIPart } from "ai";
-import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/native/accordion";
 import { Spinner } from "@/components/ui/spinner";
 import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
 import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
-import { cn } from "@/lib/utils";
 
 interface GetSettingInput {
   key: string;
-}
-
-interface GetSettingOutput {
-  key: string;
-  type: string;
-  options: unknown[] | null;
-  value: unknown;
 }
 
 export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
   const callId = part.toolCallId;
   const input = part.input as GetSettingInput;
   const approvalHandler = useChatApprovalHandler();
-  const [isAccordionOpen, setIsAccordionOpen] = useState<boolean | undefined>();
 
   const key = input?.key || "unknown setting";
 
@@ -46,7 +24,7 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
           <div className="flex items-center gap-1">
             <IconSettings className="text-foreground size-4 shrink-0" />
             <span className="text-foreground text-sm font-bold">
-              AgentOne wants to get setting "{key}"
+              AgentOne wants to read the "{key}" setting
             </span>
           </div>
           <div className="flex items-center justify-end gap-2">
@@ -75,7 +53,7 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
         <div key={callId} className="flex items-center gap-1">
           <IconCircleX className="text-muted-foreground size-4 shrink-0" />
           <span className="text-muted-foreground text-sm font-bold">
-            Get setting denied ({key})
+            Read "{key}" setting denied
           </span>
         </div>
       );
@@ -89,85 +67,16 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
           className="text-foreground flex flex-row items-center gap-1 text-sm font-bold"
         >
           <Spinner className="text-foreground size-4 shrink-0" />
-          <span className="max-w-2xl truncate">Getting setting "{key}"...</span>
+          <span className="max-w-2xl truncate">Reading "{key}" setting...</span>
         </div>
       );
 
     case "output-available": {
-      const output = part.output as GetSettingOutput;
-
       return (
-        <Accordion
-          type="single"
-          collapsible
-          onValueChange={(value) => setIsAccordionOpen(value === callId)}
-          className="text-foreground flex w-full flex-row bg-transparent p-0 text-sm"
-        >
-          <AccordionItem
-            value={callId}
-            className={cn(
-              "group/get-setting-accordion border-border w-full rounded-md border-0 transition-[padding] duration-200",
-              isAccordionOpen && "border border-b! p-2",
-            )}
-          >
-            <AccordionTrigger
-              icon={
-                <div className="relative">
-                  <IconSettings
-                    className={cn(
-                      "text-foreground absolute inset-0 size-4 shrink-0 scale-100 opacity-100 transition-[opacity,scale] duration-200 group-hover/get-setting-accordion:scale-0 group-hover/get-setting-accordion:opacity-0",
-                      isAccordionOpen && "scale-0 opacity-0",
-                    )}
-                  />
-                  <IconChevronDown
-                    className={cn(
-                      "text-foreground absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/get-setting-accordion:scale-100 group-hover/get-setting-accordion:opacity-100",
-                      isAccordionOpen && "scale-100 opacity-100",
-                    )}
-                  />
-                </div>
-              }
-              iconPosition="left"
-              shouldRotateIcon={true}
-              className="justify-start gap-1 p-0 font-bold hover:no-underline"
-            >
-              <span className="max-w-2xl truncate">Retrieved setting "{key}"</span>
-            </AccordionTrigger>
-            <AccordionContent className="flex flex-col gap-2 p-0 pt-2">
-              <div className="flex gap-4">
-                <div>
-                  <span className="text-muted-foreground block text-xs">Current Value:</span>
-                  <span className="bg-muted rounded-md px-2 py-0.5 font-mono text-sm font-bold">
-                    {JSON.stringify(output?.value)}
-                  </span>
-                </div>
-                <div>
-                  <span className="text-muted-foreground block text-xs">Type:</span>
-                  <span className="bg-muted rounded-md px-2 py-0.5 font-mono text-xs">
-                    {output?.type}
-                  </span>
-                </div>
-              </div>
-              {output?.options ? (
-                <div>
-                  <span className="text-muted-foreground mb-1 block text-xs">
-                    Available Options:
-                  </span>
-                  <div className="flex flex-wrap gap-1">
-                    {output.options.map((opt) => (
-                      <span
-                        key={String(opt)}
-                        className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-xs"
-                      >
-                        {JSON.stringify(opt)}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+        <div key={callId} className="text-foreground flex items-center gap-1 text-sm font-bold">
+          <IconSettings className="text-foreground size-4 shrink-0" />
+          <span className="max-w-2xl truncate">Read "{key}" setting</span>
+        </div>
       );
     }
 
@@ -176,7 +85,9 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
         return (
           <div key={callId} className="flex items-center gap-1">
             <IconCircleX className="text-muted-foreground size-4 shrink-0" />
-            <span className="text-muted-foreground text-sm font-bold">Get setting cancelled</span>
+            <span className="text-muted-foreground text-sm font-bold">
+              Reading setting was cancelled
+            </span>
           </div>
         );
       }
@@ -191,7 +102,7 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
       return (
         <div key={callId} className="flex items-center gap-1">
           <IconSettings className="text-foreground size-4 shrink-0" />
-          <span className="text-foreground text-sm font-bold">Get setting accessed</span>
+          <span className="text-foreground text-sm font-bold">Read setting accessed</span>
         </div>
       );
   }

--- a/src/components/a1/messages/tools/tool-getSetting.tsx
+++ b/src/components/a1/messages/tools/tool-getSetting.tsx
@@ -1,10 +1,24 @@
-import { IconSettings, IconCircleX, IconX, IconCircleCheck } from "@tabler/icons-react";
+import {
+  IconChevronDown,
+  IconCircleCheck,
+  IconCircleX,
+  IconSettings,
+  IconX,
+} from "@tabler/icons-react";
 import type { ToolUIPart } from "ai";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/native/accordion";
 import { Spinner } from "@/components/ui/spinner";
 import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
 import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
+import { cn } from "@/lib/utils";
 
 interface GetSettingInput {
   key: string;
@@ -14,6 +28,7 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
   const callId = part.toolCallId;
   const input = part.input as GetSettingInput;
   const approvalHandler = useChatApprovalHandler();
+  const [isErrorAccordionOpen, setIsErrorAccordionOpen] = useState<boolean | undefined>();
 
   const key = input?.key || "unknown setting";
 
@@ -80,7 +95,7 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
       );
     }
 
-    case "output-error":
+    case "output-error": {
       if (part.errorText === TOOL_CANCELLED_BY_USER_SYMBOL) {
         return (
           <div key={callId} className="flex items-center gap-1">
@@ -91,12 +106,53 @@ export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
           </div>
         );
       }
+
       return (
-        <div key={callId} className="text-destructive flex items-center gap-1 text-sm font-bold">
-          <IconCircleX className="size-4 shrink-0" />
-          <span>Error getting setting: {part.errorText}</span>
-        </div>
+        <Accordion
+          type="single"
+          collapsible
+          onValueChange={(value) => setIsErrorAccordionOpen(value === callId)}
+          className="text-foreground flex flex-row bg-transparent p-0 text-sm"
+        >
+          <AccordionItem
+            value={callId}
+            className={cn(
+              "group/get-setting-accordion border-border w-fit max-w-full rounded-md border-0 transition-[padding] duration-200",
+              isErrorAccordionOpen && "border border-b! p-2",
+            )}
+          >
+            <AccordionTrigger
+              icon={
+                <div className="relative">
+                  <IconCircleX
+                    className={cn(
+                      "text-destructive absolute inset-0 size-4 shrink-0 scale-100 opacity-100 transition-[opacity,scale] duration-200 group-hover/get-setting-accordion:scale-0 group-hover/get-setting-accordion:opacity-0",
+                      isErrorAccordionOpen && "scale-0 opacity-0",
+                    )}
+                  />
+                  <IconChevronDown
+                    className={cn(
+                      "text-destructive absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/get-setting-accordion:scale-100 group-hover/get-setting-accordion:opacity-100",
+                      isErrorAccordionOpen && "scale-100 opacity-100",
+                    )}
+                  />
+                </div>
+              }
+              iconPosition="left"
+              shouldRotateIcon={true}
+              className="justify-start gap-1 p-0 font-bold hover:no-underline"
+            >
+              <span className="text-destructive max-w-2xl truncate">Error reading setting</span>
+            </AccordionTrigger>
+            <AccordionContent className="p-0 pt-2">
+              <div className="text-destructive/80 text-sm font-normal">
+                {part?.errorText || "Unknown error"}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       );
+    }
 
     default:
       return (

--- a/src/components/a1/messages/tools/tool-getSetting.tsx
+++ b/src/components/a1/messages/tools/tool-getSetting.tsx
@@ -1,0 +1,200 @@
+import {
+  IconSettings,
+  IconCircleX,
+  IconX,
+  IconCircleCheck,
+  IconChevronDown,
+} from "@tabler/icons-react";
+import type { ToolUIPart } from "ai";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/native/accordion";
+import { Spinner } from "@/components/ui/spinner";
+import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
+import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+interface GetSettingInput {
+  key: string;
+}
+
+interface GetSettingOutput {
+  key: string;
+  type: string;
+  options: unknown[] | null;
+  value: unknown;
+}
+
+export const MessagePartToolGetSetting = ({ part }: { part: ToolUIPart }) => {
+  const callId = part.toolCallId;
+  const input = part.input as GetSettingInput;
+  const approvalHandler = useChatApprovalHandler();
+  const [isAccordionOpen, setIsAccordionOpen] = useState<boolean | undefined>();
+
+  const key = input?.key || "unknown setting";
+
+  switch (part.state) {
+    case "approval-requested":
+      return (
+        <div key={callId} className="border-border flex w-fit flex-col gap-2 rounded-md border p-2">
+          <div className="flex items-center gap-1">
+            <IconSettings className="text-foreground size-4 shrink-0" />
+            <span className="text-foreground text-sm font-bold">
+              AgentOne wants to get setting "{key}"
+            </span>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => approvalHandler?.({ id: part.approval.id, approved: false })}
+            >
+              <IconX data-icon="inline-start" />
+              Deny
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => approvalHandler?.({ id: part.approval.id, approved: true })}
+            >
+              <IconCircleCheck data-icon="inline-start" />
+              Approve
+            </Button>
+          </div>
+        </div>
+      );
+
+    case "output-denied":
+      return (
+        <div key={callId} className="flex items-center gap-1">
+          <IconCircleX className="text-muted-foreground size-4 shrink-0" />
+          <span className="text-muted-foreground text-sm font-bold">
+            Get setting denied ({key})
+          </span>
+        </div>
+      );
+
+    case "input-streaming":
+    case "approval-responded":
+    case "input-available":
+      return (
+        <div
+          key={callId}
+          className="text-foreground flex flex-row items-center gap-1 text-sm font-bold"
+        >
+          <Spinner className="text-foreground size-4 shrink-0" />
+          <span className="max-w-2xl truncate">Getting setting "{key}"...</span>
+        </div>
+      );
+
+    case "output-available": {
+      const output = part.output as GetSettingOutput;
+
+      return (
+        <Accordion
+          type="single"
+          collapsible
+          onValueChange={(value) => setIsAccordionOpen(value === callId)}
+          className="text-foreground flex w-full flex-row bg-transparent p-0 text-sm"
+        >
+          <AccordionItem
+            value={callId}
+            className={cn(
+              "group/get-setting-accordion border-border w-full rounded-md border-0 transition-[padding] duration-200",
+              isAccordionOpen && "border border-b! p-2",
+            )}
+          >
+            <AccordionTrigger
+              icon={
+                <div className="relative">
+                  <IconSettings
+                    className={cn(
+                      "text-foreground absolute inset-0 size-4 shrink-0 scale-100 opacity-100 transition-[opacity,scale] duration-200 group-hover/get-setting-accordion:scale-0 group-hover/get-setting-accordion:opacity-0",
+                      isAccordionOpen && "scale-0 opacity-0",
+                    )}
+                  />
+                  <IconChevronDown
+                    className={cn(
+                      "text-foreground absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/get-setting-accordion:scale-100 group-hover/get-setting-accordion:opacity-100",
+                      isAccordionOpen && "scale-100 opacity-100",
+                    )}
+                  />
+                </div>
+              }
+              iconPosition="left"
+              shouldRotateIcon={true}
+              className="justify-start gap-1 p-0 font-bold hover:no-underline"
+            >
+              <span className="max-w-2xl truncate">Retrieved setting "{key}"</span>
+            </AccordionTrigger>
+            <AccordionContent className="flex flex-col gap-2 p-0 pt-2">
+              <div className="flex gap-4">
+                <div>
+                  <span className="text-muted-foreground block text-xs">Current Value:</span>
+                  <span className="bg-muted rounded-md px-2 py-0.5 font-mono text-sm font-bold">
+                    {JSON.stringify(output?.value)}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-muted-foreground block text-xs">Type:</span>
+                  <span className="bg-muted rounded-md px-2 py-0.5 font-mono text-xs">
+                    {output?.type}
+                  </span>
+                </div>
+              </div>
+              {output?.options ? (
+                <div>
+                  <span className="text-muted-foreground mb-1 block text-xs">
+                    Available Options:
+                  </span>
+                  <div className="flex flex-wrap gap-1">
+                    {output.options.map((opt) => (
+                      <span
+                        key={String(opt)}
+                        className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-xs"
+                      >
+                        {JSON.stringify(opt)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      );
+    }
+
+    case "output-error":
+      if (part.errorText === TOOL_CANCELLED_BY_USER_SYMBOL) {
+        return (
+          <div key={callId} className="flex items-center gap-1">
+            <IconCircleX className="text-muted-foreground size-4 shrink-0" />
+            <span className="text-muted-foreground text-sm font-bold">Get setting cancelled</span>
+          </div>
+        );
+      }
+      return (
+        <div key={callId} className="text-destructive flex items-center gap-1 text-sm font-bold">
+          <IconCircleX className="size-4 shrink-0" />
+          <span>Error getting setting: {part.errorText}</span>
+        </div>
+      );
+
+    default:
+      return (
+        <div key={callId} className="flex items-center gap-1">
+          <IconSettings className="text-foreground size-4 shrink-0" />
+          <span className="text-foreground text-sm font-bold">Get setting accessed</span>
+        </div>
+      );
+  }
+};
+
+MessagePartToolGetSetting.displayName = "MessagePartToolGetSetting";

--- a/src/components/a1/messages/tools/tool-listSettings.tsx
+++ b/src/components/a1/messages/tools/tool-listSettings.tsx
@@ -1,33 +1,14 @@
-import {
-  IconSettings,
-  IconCircleX,
-  IconX,
-  IconCircleCheck,
-  IconChevronDown,
-} from "@tabler/icons-react";
+import { IconSettings, IconCircleX, IconX, IconCircleCheck } from "@tabler/icons-react";
 import type { ToolUIPart } from "ai";
-import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/native/accordion";
 import { Spinner } from "@/components/ui/spinner";
 import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
 import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
-import { cn } from "@/lib/utils";
-
-interface ListSettingsOutput {
-  keys?: string[];
-}
 
 export const MessagePartToolListSettings = ({ part }: { part: ToolUIPart }) => {
   const callId = part.toolCallId;
   const approvalHandler = useChatApprovalHandler();
-  const [isAccordionOpen, setIsAccordionOpen] = useState<boolean | undefined>();
 
   switch (part.state) {
     case "approval-requested":
@@ -82,60 +63,14 @@ export const MessagePartToolListSettings = ({ part }: { part: ToolUIPart }) => {
       );
 
     case "output-available": {
-      const output = part.output as ListSettingsOutput;
-      const keysCount = output?.keys?.length ?? 0;
-
       return (
-        <Accordion
-          type="single"
-          collapsible
-          onValueChange={(value) => setIsAccordionOpen(value === callId)}
-          className="text-foreground flex w-full flex-row bg-transparent p-0 text-sm"
+        <div
+          key={callId}
+          className="text-foreground flex flex-row items-center gap-1 text-sm font-bold"
         >
-          <AccordionItem
-            value={callId}
-            className={cn(
-              "group/list-settings-accordion border-border w-full rounded-md border-0 transition-[padding] duration-200",
-              isAccordionOpen && "border border-b! p-2",
-            )}
-          >
-            <AccordionTrigger
-              icon={
-                <div className="relative">
-                  <IconSettings
-                    className={cn(
-                      "text-foreground absolute inset-0 size-4 shrink-0 scale-100 opacity-100 transition-[opacity,scale] duration-200 group-hover/list-settings-accordion:scale-0 group-hover/list-settings-accordion:opacity-0",
-                      isAccordionOpen && "scale-0 opacity-0",
-                    )}
-                  />
-                  <IconChevronDown
-                    className={cn(
-                      "text-foreground absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/list-settings-accordion:scale-100 group-hover/list-settings-accordion:opacity-100",
-                      isAccordionOpen && "scale-100 opacity-100",
-                    )}
-                  />
-                </div>
-              }
-              iconPosition="left"
-              shouldRotateIcon={true}
-              className="justify-start gap-1 p-0 font-bold hover:no-underline"
-            >
-              <span className="max-w-2xl truncate">Listed {keysCount} settings keys</span>
-            </AccordionTrigger>
-            <AccordionContent className="p-0 pt-2">
-              <div className="flex flex-wrap gap-1.5">
-                {output?.keys?.map((key) => (
-                  <span
-                    key={key}
-                    className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-xs"
-                  >
-                    {key}
-                  </span>
-                ))}
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+          <IconSettings className="text-foreground size-4 shrink-0" />
+          <span className="max-w-2xl truncate">Looked at desktop app settings</span>
+        </div>
       );
     }
 

--- a/src/components/a1/messages/tools/tool-listSettings.tsx
+++ b/src/components/a1/messages/tools/tool-listSettings.tsx
@@ -1,0 +1,168 @@
+import {
+  IconSettings,
+  IconCircleX,
+  IconX,
+  IconCircleCheck,
+  IconChevronDown,
+} from "@tabler/icons-react";
+import type { ToolUIPart } from "ai";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/native/accordion";
+import { Spinner } from "@/components/ui/spinner";
+import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
+import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+interface ListSettingsOutput {
+  keys?: string[];
+}
+
+export const MessagePartToolListSettings = ({ part }: { part: ToolUIPart }) => {
+  const callId = part.toolCallId;
+  const approvalHandler = useChatApprovalHandler();
+  const [isAccordionOpen, setIsAccordionOpen] = useState<boolean | undefined>();
+
+  switch (part.state) {
+    case "approval-requested":
+      return (
+        <div key={callId} className="border-border flex w-fit flex-col gap-2 rounded-md border p-2">
+          <div className="flex items-center gap-1">
+            <IconSettings className="text-foreground size-4 shrink-0" />
+            <span className="text-foreground text-sm font-bold">
+              AgentOne wants to list settings
+            </span>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => approvalHandler?.({ id: part.approval.id, approved: false })}
+            >
+              <IconX data-icon="inline-start" />
+              Deny
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => approvalHandler?.({ id: part.approval.id, approved: true })}
+            >
+              <IconCircleCheck data-icon="inline-start" />
+              Approve
+            </Button>
+          </div>
+        </div>
+      );
+
+    case "output-denied":
+      return (
+        <div key={callId} className="flex items-center gap-1">
+          <IconCircleX className="text-muted-foreground size-4 shrink-0" />
+          <span className="text-muted-foreground text-sm font-bold">List settings denied</span>
+        </div>
+      );
+
+    case "input-streaming":
+    case "approval-responded":
+    case "input-available":
+      return (
+        <div
+          key={callId}
+          className="text-foreground flex flex-row items-center gap-1 text-sm font-bold"
+        >
+          <Spinner className="text-foreground size-4 shrink-0" />
+          <span className="max-w-2xl truncate">Listing settings...</span>
+        </div>
+      );
+
+    case "output-available": {
+      const output = part.output as ListSettingsOutput;
+      const keysCount = output?.keys?.length ?? 0;
+
+      return (
+        <Accordion
+          type="single"
+          collapsible
+          onValueChange={(value) => setIsAccordionOpen(value === callId)}
+          className="text-foreground flex w-full flex-row bg-transparent p-0 text-sm"
+        >
+          <AccordionItem
+            value={callId}
+            className={cn(
+              "group/list-settings-accordion border-border w-full rounded-md border-0 transition-[padding] duration-200",
+              isAccordionOpen && "border border-b! p-2",
+            )}
+          >
+            <AccordionTrigger
+              icon={
+                <div className="relative">
+                  <IconSettings
+                    className={cn(
+                      "text-foreground absolute inset-0 size-4 shrink-0 scale-100 opacity-100 transition-[opacity,scale] duration-200 group-hover/list-settings-accordion:scale-0 group-hover/list-settings-accordion:opacity-0",
+                      isAccordionOpen && "scale-0 opacity-0",
+                    )}
+                  />
+                  <IconChevronDown
+                    className={cn(
+                      "text-foreground absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/list-settings-accordion:scale-100 group-hover/list-settings-accordion:opacity-100",
+                      isAccordionOpen && "scale-100 opacity-100",
+                    )}
+                  />
+                </div>
+              }
+              iconPosition="left"
+              shouldRotateIcon={true}
+              className="justify-start gap-1 p-0 font-bold hover:no-underline"
+            >
+              <span className="max-w-2xl truncate">Listed {keysCount} settings keys</span>
+            </AccordionTrigger>
+            <AccordionContent className="p-0 pt-2">
+              <div className="flex flex-wrap gap-1.5">
+                {output?.keys?.map((key) => (
+                  <span
+                    key={key}
+                    className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-xs"
+                  >
+                    {key}
+                  </span>
+                ))}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      );
+    }
+
+    case "output-error":
+      if (part.errorText === TOOL_CANCELLED_BY_USER_SYMBOL) {
+        return (
+          <div key={callId} className="flex items-center gap-1">
+            <IconCircleX className="text-muted-foreground size-4 shrink-0" />
+            <span className="text-muted-foreground text-sm font-bold">List settings cancelled</span>
+          </div>
+        );
+      }
+      return (
+        <div key={callId} className="text-destructive flex items-center gap-1 text-sm font-bold">
+          <IconCircleX className="size-4 shrink-0" />
+          <span>Error listing settings: {part.errorText}</span>
+        </div>
+      );
+
+    default:
+      return (
+        <div key={callId} className="flex items-center gap-1">
+          <IconSettings className="text-foreground size-4 shrink-0" />
+          <span className="text-foreground text-sm font-bold">List settings accessed</span>
+        </div>
+      );
+  }
+};
+
+MessagePartToolListSettings.displayName = "MessagePartToolListSettings";

--- a/src/components/a1/messages/tools/tool-listSettings.tsx
+++ b/src/components/a1/messages/tools/tool-listSettings.tsx
@@ -1,14 +1,29 @@
-import { IconSettings, IconCircleX, IconX, IconCircleCheck } from "@tabler/icons-react";
+import {
+  IconChevronDown,
+  IconCircleCheck,
+  IconCircleX,
+  IconSettings,
+  IconX,
+} from "@tabler/icons-react";
 import type { ToolUIPart } from "ai";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/native/accordion";
 import { Spinner } from "@/components/ui/spinner";
 import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
 import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
+import { cn } from "@/lib/utils";
 
 export const MessagePartToolListSettings = ({ part }: { part: ToolUIPart }) => {
   const callId = part.toolCallId;
   const approvalHandler = useChatApprovalHandler();
+  const [isErrorAccordionOpen, setIsErrorAccordionOpen] = useState<boolean | undefined>();
 
   switch (part.state) {
     case "approval-requested":
@@ -74,7 +89,7 @@ export const MessagePartToolListSettings = ({ part }: { part: ToolUIPart }) => {
       );
     }
 
-    case "output-error":
+    case "output-error": {
       if (part.errorText === TOOL_CANCELLED_BY_USER_SYMBOL) {
         return (
           <div key={callId} className="flex items-center gap-1">
@@ -83,12 +98,53 @@ export const MessagePartToolListSettings = ({ part }: { part: ToolUIPart }) => {
           </div>
         );
       }
+
       return (
-        <div key={callId} className="text-destructive flex items-center gap-1 text-sm font-bold">
-          <IconCircleX className="size-4 shrink-0" />
-          <span>Error listing settings: {part.errorText}</span>
-        </div>
+        <Accordion
+          type="single"
+          collapsible
+          onValueChange={(value) => setIsErrorAccordionOpen(value === callId)}
+          className="text-foreground flex flex-row bg-transparent p-0 text-sm"
+        >
+          <AccordionItem
+            value={callId}
+            className={cn(
+              "group/list-settings-accordion border-border w-fit max-w-full rounded-md border-0 transition-[padding] duration-200",
+              isErrorAccordionOpen && "border border-b! p-2",
+            )}
+          >
+            <AccordionTrigger
+              icon={
+                <div className="relative">
+                  <IconCircleX
+                    className={cn(
+                      "text-destructive absolute inset-0 size-4 shrink-0 scale-100 opacity-100 transition-[opacity,scale] duration-200 group-hover/list-settings-accordion:scale-0 group-hover/list-settings-accordion:opacity-0",
+                      isErrorAccordionOpen && "scale-0 opacity-0",
+                    )}
+                  />
+                  <IconChevronDown
+                    className={cn(
+                      "text-destructive absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/list-settings-accordion:scale-100 group-hover/list-settings-accordion:opacity-100",
+                      isErrorAccordionOpen && "scale-100 opacity-100",
+                    )}
+                  />
+                </div>
+              }
+              iconPosition="left"
+              shouldRotateIcon={true}
+              className="justify-start gap-1 p-0 font-bold hover:no-underline"
+            >
+              <span className="text-destructive max-w-2xl truncate">Error listing settings</span>
+            </AccordionTrigger>
+            <AccordionContent className="p-0 pt-2">
+              <div className="text-destructive/80 text-sm font-normal">
+                {part?.errorText || "Unknown error"}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       );
+    }
 
     default:
       return (

--- a/src/components/a1/messages/tools/tool-updateSetting.tsx
+++ b/src/components/a1/messages/tools/tool-updateSetting.tsx
@@ -1,16 +1,25 @@
 import {
-  IconSettings,
+  IconChevronDown,
   IconCircleX,
-  IconX,
   IconCircleCheck,
+  IconSettings,
   IconSettingsCheck,
+  IconX,
 } from "@tabler/icons-react";
 import type { ToolUIPart } from "ai";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/native/accordion";
 import { Spinner } from "@/components/ui/spinner";
 import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
 import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
+import { cn } from "@/lib/utils";
 
 interface UpdateSettingInput {
   key: string;
@@ -27,6 +36,7 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
   const callId = part.toolCallId;
   const input = part.input as UpdateSettingInput;
   const approvalHandler = useChatApprovalHandler();
+  const [isErrorAccordionOpen, setIsErrorAccordionOpen] = useState<boolean | undefined>();
 
   const key = input?.key || "unknown setting";
   const value = input?.value !== undefined ? JSON.stringify(input.value) : "undefined";
@@ -103,7 +113,7 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
       );
     }
 
-    case "output-error":
+    case "output-error": {
       if (part.errorText === TOOL_CANCELLED_BY_USER_SYMBOL) {
         return (
           <div key={callId} className="flex items-center gap-1">
@@ -114,12 +124,53 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
           </div>
         );
       }
+
       return (
-        <div key={callId} className="text-destructive flex items-center gap-1 text-sm font-bold">
-          <IconCircleX className="size-4 shrink-0" />
-          <span>Error updating setting: {part.errorText}</span>
-        </div>
+        <Accordion
+          type="single"
+          collapsible
+          onValueChange={(value) => setIsErrorAccordionOpen(value === callId)}
+          className="text-foreground flex flex-row bg-transparent p-0 text-sm"
+        >
+          <AccordionItem
+            value={callId}
+            className={cn(
+              "group/update-setting-accordion border-border w-fit max-w-full rounded-md border-0 transition-[padding] duration-200",
+              isErrorAccordionOpen && "border border-b! p-2",
+            )}
+          >
+            <AccordionTrigger
+              icon={
+                <div className="relative">
+                  <IconCircleX
+                    className={cn(
+                      "text-destructive absolute inset-0 size-4 shrink-0 scale-100 opacity-100 transition-[opacity,scale] duration-200 group-hover/update-setting-accordion:scale-0 group-hover/update-setting-accordion:opacity-0",
+                      isErrorAccordionOpen && "scale-0 opacity-0",
+                    )}
+                  />
+                  <IconChevronDown
+                    className={cn(
+                      "text-destructive absolute inset-0 size-4 shrink-0 scale-0 opacity-0 transition-[opacity,scale] duration-200 group-hover/update-setting-accordion:scale-100 group-hover/update-setting-accordion:opacity-100",
+                      isErrorAccordionOpen && "scale-100 opacity-100",
+                    )}
+                  />
+                </div>
+              }
+              iconPosition="left"
+              shouldRotateIcon={true}
+              className="justify-start gap-1 p-0 font-bold hover:no-underline"
+            >
+              <span className="text-destructive max-w-2xl truncate">Error updating setting</span>
+            </AccordionTrigger>
+            <AccordionContent className="p-0 pt-2">
+              <div className="text-destructive/80 text-sm font-normal">
+                {part?.errorText || "Unknown error"}
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       );
+    }
 
     default:
       return (

--- a/src/components/a1/messages/tools/tool-updateSetting.tsx
+++ b/src/components/a1/messages/tools/tool-updateSetting.tsx
@@ -1,0 +1,128 @@
+import { IconSettings, IconCircleX, IconX, IconCircleCheck } from "@tabler/icons-react";
+import type { ToolUIPart } from "ai";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { useChatApprovalHandler } from "@/contexts/use-chat/chat-hooks";
+import { TOOL_CANCELLED_BY_USER_SYMBOL } from "@/lib/constants";
+
+interface UpdateSettingInput {
+  key: string;
+  value: unknown;
+}
+
+interface UpdateSettingOutput {
+  key: string;
+  value: unknown;
+  success: boolean;
+}
+
+export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => {
+  const callId = part.toolCallId;
+  const input = part.input as UpdateSettingInput;
+  const approvalHandler = useChatApprovalHandler();
+
+  const key = input?.key || "unknown setting";
+  const value = input?.value !== undefined ? JSON.stringify(input.value) : "undefined";
+
+  switch (part.state) {
+    case "approval-requested":
+      return (
+        <div key={callId} className="border-border flex w-fit flex-col gap-2 rounded-md border p-2">
+          <div className="flex items-center gap-1">
+            <IconSettings className="text-foreground size-4 shrink-0" />
+            <span className="text-foreground text-sm font-bold">
+              AgentOne wants to update setting "{key}" to "{value}"
+            </span>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => approvalHandler?.({ id: part.approval.id, approved: false })}
+            >
+              <IconX data-icon="inline-start" />
+              Deny
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => approvalHandler?.({ id: part.approval.id, approved: true })}
+            >
+              <IconCircleCheck data-icon="inline-start" />
+              Approve
+            </Button>
+          </div>
+        </div>
+      );
+
+    case "output-denied":
+      return (
+        <div key={callId} className="flex items-center gap-1">
+          <IconCircleX className="text-muted-foreground size-4 shrink-0" />
+          <span className="text-muted-foreground text-sm font-bold">
+            Update setting denied ({key})
+          </span>
+        </div>
+      );
+
+    case "input-streaming":
+    case "approval-responded":
+    case "input-available":
+      return (
+        <div
+          key={callId}
+          className="text-foreground flex flex-row items-center gap-1 text-sm font-bold"
+        >
+          <Spinner className="text-foreground size-4 shrink-0" />
+          <span className="max-w-2xl truncate">
+            Updating setting "{key}" to "{value}"...
+          </span>
+        </div>
+      );
+
+    case "output-available": {
+      const output = part.output as UpdateSettingOutput;
+
+      return (
+        <div
+          key={callId}
+          className="text-foreground flex flex-row items-center gap-1.5 text-sm font-bold"
+        >
+          <IconCircleCheck className="size-4 shrink-0 text-green-500" />
+          <span className="max-w-2xl truncate">
+            Updated setting "{key}" to "{JSON.stringify(output?.value)}"
+          </span>
+        </div>
+      );
+    }
+
+    case "output-error":
+      if (part.errorText === TOOL_CANCELLED_BY_USER_SYMBOL) {
+        return (
+          <div key={callId} className="flex items-center gap-1">
+            <IconCircleX className="text-muted-foreground size-4 shrink-0" />
+            <span className="text-muted-foreground text-sm font-bold">
+              Update setting cancelled
+            </span>
+          </div>
+        );
+      }
+      return (
+        <div key={callId} className="text-destructive flex items-center gap-1 text-sm font-bold">
+          <IconCircleX className="size-4 shrink-0" />
+          <span>Error updating setting: {part.errorText}</span>
+        </div>
+      );
+
+    default:
+      return (
+        <div key={callId} className="flex items-center gap-1">
+          <IconSettings className="text-foreground size-4 shrink-0" />
+          <span className="text-foreground text-sm font-bold">Update setting accessed</span>
+        </div>
+      );
+  }
+};
+
+MessagePartToolUpdateSetting.displayName = "MessagePartToolUpdateSetting";

--- a/src/components/a1/messages/tools/tool-updateSetting.tsx
+++ b/src/components/a1/messages/tools/tool-updateSetting.tsx
@@ -1,4 +1,10 @@
-import { IconSettings, IconCircleX, IconX, IconCircleCheck } from "@tabler/icons-react";
+import {
+  IconSettings,
+  IconCircleX,
+  IconX,
+  IconCircleCheck,
+  IconSettingsCheck,
+} from "@tabler/icons-react";
 import type { ToolUIPart } from "ai";
 
 import { Button } from "@/components/ui/button";
@@ -32,7 +38,7 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
           <div className="flex items-center gap-1">
             <IconSettings className="text-foreground size-4 shrink-0" />
             <span className="text-foreground text-sm font-bold">
-              AgentOne wants to update setting "{key}" to "{value}"
+              AgentOne wants to update "{key}" setting to {value}
             </span>
           </div>
           <div className="flex items-center justify-end gap-2">
@@ -61,7 +67,7 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
         <div key={callId} className="flex items-center gap-1">
           <IconCircleX className="text-muted-foreground size-4 shrink-0" />
           <span className="text-muted-foreground text-sm font-bold">
-            Update setting denied ({key})
+            Update "{key}" setting denied
           </span>
         </div>
       );
@@ -76,7 +82,7 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
         >
           <Spinner className="text-foreground size-4 shrink-0" />
           <span className="max-w-2xl truncate">
-            Updating setting "{key}" to "{value}"...
+            Updating "{key}" setting to {value}...
           </span>
         </div>
       );
@@ -89,9 +95,9 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
           key={callId}
           className="text-foreground flex flex-row items-center gap-1.5 text-sm font-bold"
         >
-          <IconCircleCheck className="size-4 shrink-0" />
+          <IconSettingsCheck className="size-4 shrink-0" />
           <span className="max-w-2xl truncate">
-            Updated setting "{key}" to "{JSON.stringify(output?.value)}"
+            Updated "{key}" setting to {JSON.stringify(output?.value)}
           </span>
         </div>
       );
@@ -103,7 +109,7 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
           <div key={callId} className="flex items-center gap-1">
             <IconCircleX className="text-muted-foreground size-4 shrink-0" />
             <span className="text-muted-foreground text-sm font-bold">
-              Update setting cancelled
+              Updating setting was cancelled
             </span>
           </div>
         );

--- a/src/components/a1/messages/tools/tool-updateSetting.tsx
+++ b/src/components/a1/messages/tools/tool-updateSetting.tsx
@@ -89,7 +89,7 @@ export const MessagePartToolUpdateSetting = ({ part }: { part: ToolUIPart }) => 
           key={callId}
           className="text-foreground flex flex-row items-center gap-1.5 text-sm font-bold"
         >
-          <IconCircleCheck className="size-4 shrink-0 text-green-500" />
+          <IconCircleCheck className="size-4 shrink-0" />
           <span className="max-w-2xl truncate">
             Updated setting "{key}" to "{JSON.stringify(output?.value)}"
           </span>

--- a/src/contexts/use-tools/tools-context.tsx
+++ b/src/contexts/use-tools/tools-context.tsx
@@ -16,6 +16,9 @@ import {
   createWaitTool,
   createWebSearchTool,
   createWikipediaTool,
+  createListSettingsTool,
+  createGetSettingTool,
+  createUpdateSettingTool,
 } from "@/lib/ai/tools";
 import {
   abortMcpServerLoad,
@@ -399,6 +402,15 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
           ...toolConfigs.executeCommand,
         },
         subAgent: { ...DEFAULT_SETTINGS.TOOL_CONFIGS.subAgent, ...toolConfigs.subAgent },
+        listSettings: {
+          ...DEFAULT_SETTINGS.TOOL_CONFIGS.listSettings,
+          ...toolConfigs.listSettings,
+        },
+        getSetting: { ...DEFAULT_SETTINGS.TOOL_CONFIGS.getSetting, ...toolConfigs.getSetting },
+        updateSetting: {
+          ...DEFAULT_SETTINGS.TOOL_CONFIGS.updateSetting,
+          ...toolConfigs.updateSetting,
+        },
       };
 
       if (mergedEnabledTools.dateTime) {
@@ -444,6 +456,17 @@ export const ToolsProvider: React.FC<ToolsProviderProps> = ({ children }) => {
         filteredStaticTools.subAgent = createSubAgentTool(
           mergedToolConfigs.subAgent,
           options.subAgentContext,
+        );
+      }
+      if (mergedEnabledTools.listSettings) {
+        filteredStaticTools.listSettings = createListSettingsTool(mergedToolConfigs.listSettings);
+      }
+      if (mergedEnabledTools.getSetting) {
+        filteredStaticTools.getSetting = createGetSettingTool(mergedToolConfigs.getSetting);
+      }
+      if (mergedEnabledTools.updateSetting) {
+        filteredStaticTools.updateSetting = createUpdateSettingTool(
+          mergedToolConfigs.updateSetting,
         );
       }
 

--- a/src/lib/ai/tools/getSetting.ts
+++ b/src/lib/ai/tools/getSetting.ts
@@ -8,7 +8,7 @@ import type { GetSettingToolConfig } from "@/lib/settings/types";
 export const createGetSettingTool = (config: GetSettingToolConfig) =>
   tool({
     description:
-      "Get the current value and metadata (including possible options) of a specific setting key.",
+      "Get the current value and metadata (including possible options) of a specific AI-accessible setting key in the desktop application.",
     needsApproval: config.requiresApproval,
     inputSchema: z.object({
       key: z

--- a/src/lib/ai/tools/getSetting.ts
+++ b/src/lib/ai/tools/getSetting.ts
@@ -1,0 +1,34 @@
+import { tool } from "ai";
+import { getDefaultStore, type Atom } from "jotai";
+import { z } from "zod";
+
+import { getInspectableKeys, getSettingAtom, getSettingMetadata } from "@/lib/settings/metadata";
+import type { GetSettingToolConfig } from "@/lib/settings/types";
+
+export const createGetSettingTool = (config: GetSettingToolConfig) =>
+  tool({
+    description:
+      "Get the current value and metadata (including possible options) of a specific setting key.",
+    needsApproval: config.requiresApproval,
+    inputSchema: z.object({
+      key: z
+        .string()
+        .describe("The setting key to retrieve. Must be one of the listed setting keys."),
+    }),
+    execute: async (input) => {
+      const { key } = input;
+      if (!getInspectableKeys().includes(key)) {
+        throw new Error(`Setting key "${key}" is not valid or inspectable.`);
+      }
+
+      const metadata = getSettingMetadata(key);
+      const store = getDefaultStore();
+      const atom = getSettingAtom(key);
+      const value = store.get(atom as Atom<unknown>);
+
+      return {
+        ...metadata,
+        value,
+      };
+    },
+  });

--- a/src/lib/ai/tools/getSetting.ts
+++ b/src/lib/ai/tools/getSetting.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { getDefaultStore, type Atom } from "jotai";
 import { z } from "zod";
 
-import { getInspectableKeys, getSettingAtom, getSettingMetadata } from "@/lib/settings/metadata";
+import { getSettingAtom, getSettingMetadata, isInspectableKey } from "@/lib/settings/metadata";
 import type { GetSettingToolConfig } from "@/lib/settings/types";
 
 export const createGetSettingTool = (config: GetSettingToolConfig) =>
@@ -17,7 +17,7 @@ export const createGetSettingTool = (config: GetSettingToolConfig) =>
     }),
     execute: async (input) => {
       const { key } = input;
-      if (!getInspectableKeys().includes(key)) {
+      if (!isInspectableKey(key)) {
         throw new Error(`Setting key "${key}" is not valid or inspectable.`);
       }
 

--- a/src/lib/ai/tools/index.ts
+++ b/src/lib/ai/tools/index.ts
@@ -11,3 +11,6 @@ export { createViewFileTool } from "./viewFile";
 export { createWaitTool } from "./waitNumberMilliseconds";
 export { createWebSearchTool } from "./webSearch";
 export { createWikipediaTool } from "./wikipedia";
+export { createListSettingsTool } from "./listSettings";
+export { createGetSettingTool } from "./getSetting";
+export { createUpdateSettingTool } from "./updateSetting";

--- a/src/lib/ai/tools/listSettings.ts
+++ b/src/lib/ai/tools/listSettings.ts
@@ -1,0 +1,17 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { getInspectableKeys } from "@/lib/settings/metadata";
+import type { ListSettingsToolConfig } from "@/lib/settings/types";
+
+export const createListSettingsTool = (config: ListSettingsToolConfig) =>
+  tool({
+    description: "List all inspectable settings keys.",
+    needsApproval: config.requiresApproval,
+    inputSchema: z.object({}),
+    execute: async () => {
+      return {
+        keys: getInspectableKeys(),
+      };
+    },
+  });

--- a/src/lib/ai/tools/listSettings.ts
+++ b/src/lib/ai/tools/listSettings.ts
@@ -6,7 +6,7 @@ import type { ListSettingsToolConfig } from "@/lib/settings/types";
 
 export const createListSettingsTool = (config: ListSettingsToolConfig) =>
   tool({
-    description: "List all inspectable settings keys.",
+    description: "List the keys of all AI-accessible settings in the desktop application.",
     needsApproval: config.requiresApproval,
     inputSchema: z.object({}),
     execute: async () => {

--- a/src/lib/ai/tools/updateSetting.ts
+++ b/src/lib/ai/tools/updateSetting.ts
@@ -7,7 +7,7 @@ import type { UpdateSettingToolConfig } from "@/lib/settings/types";
 
 export const createUpdateSettingTool = (config: UpdateSettingToolConfig) =>
   tool({
-    description: "Update a specific setting key's value.",
+    description: "Update a specific AI-accessible setting key's value.",
     needsApproval: config.requiresApproval,
     inputSchema: z.object({
       key: z

--- a/src/lib/ai/tools/updateSetting.ts
+++ b/src/lib/ai/tools/updateSetting.ts
@@ -1,0 +1,43 @@
+import { tool } from "ai";
+import { getDefaultStore, type WritableAtom } from "jotai";
+import { z } from "zod";
+
+import { getInspectableKeys, getSettingAtom, validateSettingValue } from "@/lib/settings/metadata";
+import type { UpdateSettingToolConfig } from "@/lib/settings/types";
+
+export const createUpdateSettingTool = (config: UpdateSettingToolConfig) =>
+  tool({
+    description: "Update a specific setting key's value.",
+    needsApproval: config.requiresApproval,
+    inputSchema: z.object({
+      key: z
+        .string()
+        .describe("The setting key to update. Must be one of the listed setting keys."),
+      value: z
+        .any()
+        .describe(
+          "The new value to write. Must be one of the possible options for enum or boolean settings.",
+        ),
+    }),
+    execute: async (input) => {
+      const { key, value } = input;
+      if (!getInspectableKeys().includes(key)) {
+        throw new Error(`Setting key "${key}" is not valid or inspectable.`);
+      }
+
+      const validation = validateSettingValue(key, value);
+      if (!validation.success) {
+        throw new Error(validation.error);
+      }
+
+      const store = getDefaultStore();
+      const atom = getSettingAtom(key) as WritableAtom<unknown, [unknown], void>;
+      store.set(atom, value);
+
+      return {
+        key,
+        value,
+        success: true,
+      };
+    },
+  });

--- a/src/lib/ai/tools/updateSetting.ts
+++ b/src/lib/ai/tools/updateSetting.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { getDefaultStore, type WritableAtom } from "jotai";
 import { z } from "zod";
 
-import { getInspectableKeys, getSettingAtom, validateSettingValue } from "@/lib/settings/metadata";
+import { getSettingAtom, isInspectableKey, validateSettingValue } from "@/lib/settings/metadata";
 import type { UpdateSettingToolConfig } from "@/lib/settings/types";
 
 export const createUpdateSettingTool = (config: UpdateSettingToolConfig) =>
@@ -21,7 +21,7 @@ export const createUpdateSettingTool = (config: UpdateSettingToolConfig) =>
     }),
     execute: async (input) => {
       const { key, value } = input;
-      if (!getInspectableKeys().includes(key)) {
+      if (!isInspectableKey(key)) {
         throw new Error(`Setting key "${key}" is not valid or inspectable.`);
       }
 

--- a/src/lib/jotai/atoms.ts
+++ b/src/lib/jotai/atoms.ts
@@ -71,12 +71,12 @@ export const systemPromptAtom = atom((get) => {
 
   return dedent`
     ## Guidelines
-    You are AgentOne, a helpful AI agent. You are currently being accessed via the [AgentOne desktop app](https://www.agent-one.dev/). To extend your capabilities beyond the tools you already have, the user can install extensions for you to use. They can do so by clicking "Settings" in the bottom left of the app sidebar (when expanded), then choosing the "Extensions" tab. There are over 11,000 extensions available.
+    You are AgentOne, a helpful AI agent. You are currently being accessed via the [AgentOne desktop app](https://www.agent-one.dev/). Documentation for AgentOne can be found at https://docs.agent-one.dev/docs/. To extend your capabilities beyond the tools you already have, the user can install extensions for you to use. They can do so by clicking "Settings" in the bottom left of the app sidebar (when expanded), then choosing the "Extensions" tab. There are over 11,000 extensions available.
     When the \`describeNextTool\` function is available, you _always_ use it before you use a tool beginning with \`mcp__\`. If you use multiple tools beginning with \`mcp__\` at once, you always use \`describeNextTool\` before each one.
     When the \`memory\` tool is available, you use it to store facts about the user across chats. You always do this when applicable to personalize responses, or when the user asks you to remember something. You don't have to be explicit in your use of the tool - if you update your memory, you don't need to mention it. Prefer small targeted additions, deletions, or edits. Avoid adding duplicates or contradictory entries. Save stable, reusable information that is likely to help in future chats.
+    ## Application Usage
+    When the \`listSettings\`, \`getSetting\`, and \`updateSetting\` tools are available, you can use them to change the desktop app behavior. Note that not all settings are accessible to you - there may be settings that you do not know about. If you are unsure what a setting does, do not make assumptions - you could search for it in the documentation or explain that you aren't certain.
     ${settings ? `\n## User settings:\n${settings}` : ""}
     ${memorySection ? `\n## User memory:\n${memorySection}` : ""}
-    ## Application Usage
-    When the \`listSettings\` and other settings tools are available, you can use them to change the desktop app behavior. Note that not all settings are accessible to you, there may be settings that you do not know about. You can read the AgentOne docs at https://docs.agent-one.dev/docs/ for further information about a setting.
   `.trim();
 });

--- a/src/lib/jotai/atoms.ts
+++ b/src/lib/jotai/atoms.ts
@@ -76,5 +76,7 @@ export const systemPromptAtom = atom((get) => {
     When the \`memory\` tool is available, you use it to store facts about the user across chats. You always do this when applicable to personalize responses, or when the user asks you to remember something. You don't have to be explicit in your use of the tool - if you update your memory, you don't need to mention it. Prefer small targeted additions, deletions, or edits. Avoid adding duplicates or contradictory entries. Save stable, reusable information that is likely to help in future chats.
     ${settings ? `\n## User settings:\n${settings}` : ""}
     ${memorySection ? `\n## User memory:\n${memorySection}` : ""}
+    ## Application Usage
+    When the \`listSettings\` and other settings tools are available, you can use them to change the desktop app behavior. Note that not all settings are accessible to you, there may be settings that you do not know about. You can read the AgentOne docs at https://docs.agent-one.dev/docs/ for further information about a setting.
   `.trim();
 });

--- a/src/lib/settings/metadata.ts
+++ b/src/lib/settings/metadata.ts
@@ -1,35 +1,90 @@
-import * as atoms from "@/lib/jotai/settings-atoms";
+import type { Atom } from "jotai";
+
+import {
+  analyticsIdentityAtom,
+  chatSortAtom,
+  chatVirtualizationModeAtom,
+  chatVirtualizationThresholdAtom,
+  collapsedSidebarLayoutAtom,
+  colorThemeAtom,
+  experimentalThrottleEnabledAtom,
+  experimentalThrottleValueAtom,
+  extractReasoningEnabledAtom,
+  fontAtom,
+  inputStyleAtom,
+  keyboardShortcutsEnabledInInputsAtom,
+  markdownHighlightingAtom,
+  markdownRenderingAtom,
+  maxCodeblockCharsAtom,
+  maxMessageLengthAtom,
+  maxToolResultCharsAtom,
+  mcpParallelLoadLimitAtom,
+  notificationSettingAtom,
+  regenerateOnSaveAtom,
+  roundnessAtom,
+  showChatStatusIndicatorAtom,
+  showMessageActionRowAtom,
+  smoothStreamEnabledAtom,
+  stopButtonBehaviorAtom,
+  submitKeyAtom,
+  systemPromptAppendixAtom,
+  textScaleAtom,
+  themeAtom,
+  uiTintAtom,
+  uiTintStrengthAtom,
+  userNameAtom,
+} from "@/lib/jotai/settings-atoms";
 
 import { DEFAULT_SETTINGS } from "./types";
 import * as types from "./types";
 
-function keyToAtomName(key: string): string {
-  if (key === "TTS") return "ttsSettingsAtom";
-  const camelCase = key.toLowerCase().replace(/_([a-z])/g, (_, char) => char.toUpperCase());
-  return `${camelCase}Atom`;
+const inspectableSettingAtoms = {
+  ANALYTICS_IDENTITY: analyticsIdentityAtom,
+  CHAT_SORT: chatSortAtom,
+  CHAT_VIRTUALIZATION_MODE: chatVirtualizationModeAtom,
+  CHAT_VIRTUALIZATION_THRESHOLD: chatVirtualizationThresholdAtom,
+  COLLAPSED_SIDEBAR_LAYOUT: collapsedSidebarLayoutAtom,
+  COLOR_THEME: colorThemeAtom,
+  EXPERIMENTAL_THROTTLE_ENABLED: experimentalThrottleEnabledAtom,
+  EXPERIMENTAL_THROTTLE_VALUE: experimentalThrottleValueAtom,
+  EXTRACT_REASONING_ENABLED: extractReasoningEnabledAtom,
+  FONT: fontAtom,
+  INPUT_STYLE: inputStyleAtom,
+  KEYBOARD_SHORTCUTS_ENABLED_IN_INPUTS: keyboardShortcutsEnabledInInputsAtom,
+  MARKDOWN_HIGHLIGHTING: markdownHighlightingAtom,
+  MARKDOWN_RENDERING: markdownRenderingAtom,
+  MAX_CODEBLOCK_CHARS: maxCodeblockCharsAtom,
+  MAX_MESSAGE_LENGTH: maxMessageLengthAtom,
+  MAX_TOOL_RESULT_CHARS: maxToolResultCharsAtom,
+  MCP_PARALLEL_LOAD_LIMIT: mcpParallelLoadLimitAtom,
+  NOTIFICATION_SETTING: notificationSettingAtom,
+  REGENERATE_ON_SAVE: regenerateOnSaveAtom,
+  ROUNDNESS: roundnessAtom,
+  SHOW_CHAT_STATUS_INDICATOR: showChatStatusIndicatorAtom,
+  SHOW_MESSAGE_ACTION_ROW: showMessageActionRowAtom,
+  SMOOTH_STREAM_ENABLED: smoothStreamEnabledAtom,
+  STOP_BUTTON_BEHAVIOR: stopButtonBehaviorAtom,
+  SUBMIT_KEY: submitKeyAtom,
+  SYSTEM_PROMPT_APPENDIX: systemPromptAppendixAtom,
+  TEXT_SCALE: textScaleAtom,
+  THEME: themeAtom,
+  UI_TINT: uiTintAtom,
+  UI_TINT_STRENGTH: uiTintStrengthAtom,
+  USER_NAME: userNameAtom,
+} satisfies Record<string, Atom<unknown>>;
+
+type InspectableSettingKey = keyof typeof inspectableSettingAtoms;
+
+function getSettingOptions(key: InspectableSettingKey): readonly unknown[] | undefined {
+  return (types as unknown as Record<string, readonly unknown[] | undefined>)[`${key}_OPTIONS`];
+}
+
+export function isInspectableKey(key: string): key is InspectableSettingKey {
+  return key in inspectableSettingAtoms;
 }
 
 export function getInspectableKeys(): string[] {
-  return Object.keys(DEFAULT_SETTINGS).filter((key) => {
-    // Exclude security tokens, complex maps, and objects
-    if (
-      key.endsWith("_API_KEY") ||
-      key.endsWith("_TOKEN") ||
-      key === "ABLIT_KEY" ||
-      key === "AGENT_ONE_API_KEY" ||
-      key === "KEYBOARD_SHORTCUTS" ||
-      key === "MCP_SERVERS" ||
-      key === "TOOL_CONFIGS" ||
-      key === "ENABLED_TOOLS" ||
-      key === "CHAT_BACKGROUND" ||
-      key === "MEMORY"
-    ) {
-      return false;
-    }
-
-    const atomName = keyToAtomName(key);
-    return atomName in atoms;
-  });
+  return Object.keys(inspectableSettingAtoms);
 }
 
 export interface SettingMetadata {
@@ -40,32 +95,23 @@ export interface SettingMetadata {
 }
 
 export function getSettingMetadata(key: string): SettingMetadata | null {
-  if (!getInspectableKeys().includes(key)) {
+  if (!isInspectableKey(key)) {
     return null;
   }
 
-  const defaultValue = DEFAULT_SETTINGS[key as keyof typeof DEFAULT_SETTINGS];
-  const optionKey = `${key}_OPTIONS`;
-  const options = (types as Record<string, unknown>)[optionKey] as readonly unknown[] | undefined;
-
-  let type: string = typeof defaultValue;
-  if (options) {
-    type = "enum";
-  } else if (Array.isArray(defaultValue)) {
-    type = "array";
-  }
+  const defaultValue = DEFAULT_SETTINGS[key];
+  const options = getSettingOptions(key);
 
   return {
     key,
-    type,
-    options: options || (type === "boolean" ? [true, false] : null),
+    type: options ? "enum" : typeof defaultValue,
+    options: options || (typeof defaultValue === "boolean" ? [true, false] : null),
     defaultValue,
   };
 }
 
 export function getSettingAtom(key: string) {
-  const atomName = keyToAtomName(key);
-  return (atoms as Record<string, unknown>)[atomName];
+  return isInspectableKey(key) ? inspectableSettingAtoms[key] : null;
 }
 
 export function validateSettingValue(
@@ -81,7 +127,7 @@ export function validateSettingValue(
     if (!metadata.options.includes(value)) {
       return {
         success: false,
-        error: `Value ${JSON.stringify(value)} is not a valid option. Valid options are: ${metadata.options.map((o) => JSON.stringify(o)).join(", ")}`,
+        error: `Value ${JSON.stringify(value)} is not a valid option. Valid options are: ${metadata.options.map((option) => JSON.stringify(option)).join(", ")}`,
       };
     }
     return { success: true };

--- a/src/lib/settings/metadata.ts
+++ b/src/lib/settings/metadata.ts
@@ -1,0 +1,99 @@
+import * as atoms from "@/lib/jotai/settings-atoms";
+
+import { DEFAULT_SETTINGS } from "./types";
+import * as types from "./types";
+
+function keyToAtomName(key: string): string {
+  if (key === "TTS") return "ttsSettingsAtom";
+  const camelCase = key.toLowerCase().replace(/_([a-z])/g, (_, char) => char.toUpperCase());
+  return `${camelCase}Atom`;
+}
+
+export function getInspectableKeys(): string[] {
+  return Object.keys(DEFAULT_SETTINGS).filter((key) => {
+    // Exclude security tokens, complex maps, and objects
+    if (
+      key.endsWith("_API_KEY") ||
+      key.endsWith("_TOKEN") ||
+      key === "ABLIT_KEY" ||
+      key === "AGENT_ONE_API_KEY" ||
+      key === "KEYBOARD_SHORTCUTS" ||
+      key === "MCP_SERVERS" ||
+      key === "TOOL_CONFIGS" ||
+      key === "ENABLED_TOOLS" ||
+      key === "CHAT_BACKGROUND" ||
+      key === "MEMORY"
+    ) {
+      return false;
+    }
+
+    const atomName = keyToAtomName(key);
+    return atomName in atoms;
+  });
+}
+
+export interface SettingMetadata {
+  key: string;
+  type: string;
+  options: readonly unknown[] | null;
+  defaultValue: unknown;
+}
+
+export function getSettingMetadata(key: string): SettingMetadata | null {
+  if (!getInspectableKeys().includes(key)) {
+    return null;
+  }
+
+  const defaultValue = DEFAULT_SETTINGS[key as keyof typeof DEFAULT_SETTINGS];
+  const optionKey = `${key}_OPTIONS`;
+  const options = (types as Record<string, unknown>)[optionKey] as readonly unknown[] | undefined;
+
+  let type: string = typeof defaultValue;
+  if (options) {
+    type = "enum";
+  } else if (Array.isArray(defaultValue)) {
+    type = "array";
+  }
+
+  return {
+    key,
+    type,
+    options: options || (type === "boolean" ? [true, false] : null),
+    defaultValue,
+  };
+}
+
+export function getSettingAtom(key: string) {
+  const atomName = keyToAtomName(key);
+  return (atoms as Record<string, unknown>)[atomName];
+}
+
+export function validateSettingValue(
+  key: string,
+  value: unknown,
+): { success: boolean; error?: string } {
+  const metadata = getSettingMetadata(key);
+  if (!metadata) {
+    return { success: false, error: `Invalid or non-inspectable setting key: "${key}"` };
+  }
+
+  if (metadata.options) {
+    if (!metadata.options.includes(value)) {
+      return {
+        success: false,
+        error: `Value ${JSON.stringify(value)} is not a valid option. Valid options are: ${metadata.options.map((o) => JSON.stringify(o)).join(", ")}`,
+      };
+    }
+    return { success: true };
+  }
+
+  const expectedType = typeof metadata.defaultValue;
+  if (typeof value !== expectedType) {
+    return {
+      success: false,
+      error: `Expected type ${expectedType}, but received ${typeof value}`,
+    };
+  }
+
+  return { success: true };
+}

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -1,4 +1,5 @@
 // If you update this file, check if you also need to update reset-settings.ts in this directory
+// Also check metadata.ts, which exposes the settings to the AI agent
 
 import type { ProviderStorageKey } from "@/lib/ai/providers/registry";
 import type { KeyboardShortcutSettings } from "@/lib/kbd-registry";

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -4,31 +4,75 @@ import type { ProviderStorageKey } from "@/lib/ai/providers/registry";
 import type { KeyboardShortcutSettings } from "@/lib/kbd-registry";
 import { defaultKeyboardShortcuts } from "@/lib/kbd-registry";
 
-export type MarkdownRenderingOption = "user" | "assistant" | "both" | "neither";
-export type SubmitKeyOption = "enter" | "ctrl-enter";
-export type ThemeOption = "light" | "dark" | "system";
-export type ColorThemeOption =
-  | "default"
-  | "red"
-  | "blue"
-  | "yellow"
-  | "green"
-  | "orange"
-  | "rose"
-  | "violet";
-export type UiTintOption = ColorThemeOption;
-export type UiTintStrengthOption = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
-export type RoundnessOption = "none" | "sm" | "md" | "lg";
-export type FontOption = "default" | "system" | "mono";
-export type TextScaleOption = "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
-export type NotificationOption = "always" | "when-unfocused" | "never";
-export type AnalyticsIdentityOption = "off" | "anonymous" | "user-id";
-export type StopButtonBehaviorOption = "at-stopping-point" | "immediate";
-export type MessageActionRowOption = "hover" | "always" | "never";
-export type InputStyleOption = "docked" | "floating";
-export type CollapsedSidebarLayoutOption = "row" | "column";
-export type ChatVirtualizationModeOption = "off" | "threshold";
-export type ChatSortOption = "created-at" | "updated-at";
+export const MARKDOWN_RENDERING_OPTIONS = ["user", "assistant", "both", "neither"] as const;
+export type MarkdownRenderingOption = (typeof MARKDOWN_RENDERING_OPTIONS)[number];
+
+export const SUBMIT_KEY_OPTIONS = ["enter", "ctrl-enter"] as const;
+export type SubmitKeyOption = (typeof SUBMIT_KEY_OPTIONS)[number];
+
+export const THEME_OPTIONS = ["light", "dark", "system"] as const;
+export type ThemeOption = (typeof THEME_OPTIONS)[number];
+
+export const COLOR_THEME_OPTIONS = [
+  "default",
+  "red",
+  "blue",
+  "yellow",
+  "green",
+  "orange",
+  "rose",
+  "violet",
+] as const;
+export type ColorThemeOption = (typeof COLOR_THEME_OPTIONS)[number];
+
+export const UI_TINT_OPTIONS = [
+  "default",
+  "red",
+  "blue",
+  "yellow",
+  "green",
+  "orange",
+  "rose",
+  "violet",
+] as const;
+export type UiTintOption = (typeof UI_TINT_OPTIONS)[number];
+
+export const UI_TINT_STRENGTH_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
+export type UiTintStrengthOption = (typeof UI_TINT_STRENGTH_OPTIONS)[number];
+
+export const ROUNDNESS_OPTIONS = ["none", "sm", "md", "lg"] as const;
+export type RoundnessOption = (typeof ROUNDNESS_OPTIONS)[number];
+
+export const FONT_OPTIONS = ["default", "system", "mono", "roboto"] as const;
+export type FontOption = (typeof FONT_OPTIONS)[number];
+
+export const TEXT_SCALE_OPTIONS = ["xs", "sm", "md", "lg", "xl", "2xl"] as const;
+export type TextScaleOption = (typeof TEXT_SCALE_OPTIONS)[number];
+
+export const NOTIFICATION_SETTING_OPTIONS = ["always", "when-unfocused", "never"] as const;
+export type NotificationOption = (typeof NOTIFICATION_SETTING_OPTIONS)[number];
+
+export const ANALYTICS_IDENTITY_OPTIONS = ["off", "anonymous", "user-id"] as const;
+export type AnalyticsIdentityOption = (typeof ANALYTICS_IDENTITY_OPTIONS)[number];
+
+export const STOP_BUTTON_BEHAVIOR_OPTIONS = ["at-stopping-point", "immediate"] as const;
+export type StopButtonBehaviorOption = (typeof STOP_BUTTON_BEHAVIOR_OPTIONS)[number];
+
+export const SHOW_MESSAGE_ACTION_ROW_OPTIONS = ["hover", "always", "never"] as const;
+export type MessageActionRowOption = (typeof SHOW_MESSAGE_ACTION_ROW_OPTIONS)[number];
+
+export const INPUT_STYLE_OPTIONS = ["docked", "floating"] as const;
+export type InputStyleOption = (typeof INPUT_STYLE_OPTIONS)[number];
+
+export const COLLAPSED_SIDEBAR_LAYOUT_OPTIONS = ["row", "column"] as const;
+export type CollapsedSidebarLayoutOption = (typeof COLLAPSED_SIDEBAR_LAYOUT_OPTIONS)[number];
+
+export const CHAT_VIRTUALIZATION_MODE_OPTIONS = ["off", "threshold"] as const;
+export type ChatVirtualizationModeOption = (typeof CHAT_VIRTUALIZATION_MODE_OPTIONS)[number];
+
+export const CHAT_SORT_OPTIONS = ["created-at", "updated-at"] as const;
+export type ChatSortOption = (typeof CHAT_SORT_OPTIONS)[number];
+
 export type ChatBackgroundPresetOption =
   | "none"
   | "custom"
@@ -151,7 +195,10 @@ export type ToolId =
   | "deleteFile"
   | "viewFile"
   | "executeCommand"
-  | "subAgent";
+  | "subAgent"
+  | "listSettings"
+  | "getSetting"
+  | "updateSetting";
 
 export interface DateTimeToolConfig {
   requiresApproval: boolean;
@@ -213,6 +260,18 @@ export interface SubAgentToolConfig {
   requiresApproval: boolean;
 }
 
+export interface ListSettingsToolConfig {
+  requiresApproval: boolean;
+}
+
+export interface GetSettingToolConfig {
+  requiresApproval: boolean;
+}
+
+export interface UpdateSettingToolConfig {
+  requiresApproval: boolean;
+}
+
 export interface ToolConfigs {
   dateTime: DateTimeToolConfig;
   waitNumberMilliseconds: WaitToolConfig;
@@ -226,6 +285,9 @@ export interface ToolConfigs {
   viewFile: ViewFileToolConfig;
   executeCommand: ExecuteCommandToolConfig;
   subAgent: SubAgentToolConfig;
+  listSettings: ListSettingsToolConfig;
+  getSetting: GetSettingToolConfig;
+  updateSetting: UpdateSettingToolConfig;
 }
 
 type ApiKeySettings = Record<ProviderStorageKey, string>;
@@ -367,6 +429,9 @@ export const DEFAULT_SETTINGS: DefaultSettings = {
     viewFile: true,
     executeCommand: true,
     subAgent: true,
+    listSettings: true,
+    getSetting: true,
+    updateSetting: true,
   },
   TOOL_CONFIGS: {
     dateTime: {
@@ -415,6 +480,15 @@ export const DEFAULT_SETTINGS: DefaultSettings = {
       defaultTimeoutMs: 120000,
     },
     subAgent: {
+      requiresApproval: true,
+    },
+    listSettings: {
+      requiresApproval: false,
+    },
+    getSetting: {
+      requiresApproval: false,
+    },
+    updateSetting: {
       requiresApproval: true,
     },
   },

--- a/src/routes/settings/sections/extensions/built-in-extensions-config.tsx
+++ b/src/routes/settings/sections/extensions/built-in-extensions-config.tsx
@@ -43,6 +43,18 @@ function getMergedToolConfigs(toolConfigs: ToolConfigs): ToolConfigs {
       ...toolConfigs.executeCommand,
     },
     subAgent: { ...DEFAULT_SETTINGS.TOOL_CONFIGS.subAgent, ...toolConfigs.subAgent },
+    listSettings: {
+      ...DEFAULT_SETTINGS.TOOL_CONFIGS.listSettings,
+      ...toolConfigs.listSettings,
+    },
+    getSetting: {
+      ...DEFAULT_SETTINGS.TOOL_CONFIGS.getSetting,
+      ...toolConfigs.getSetting,
+    },
+    updateSetting: {
+      ...DEFAULT_SETTINGS.TOOL_CONFIGS.updateSetting,
+      ...toolConfigs.updateSetting,
+    },
   };
 }
 

--- a/src/routes/settings/sections/extensions/built-in-extensions-utils.ts
+++ b/src/routes/settings/sections/extensions/built-in-extensions-utils.ts
@@ -79,7 +79,7 @@ export const BUILT_IN_TOOLS: Record<
   },
   updateSetting: {
     name: "Update Setting",
-    description: "Update a setting key's value (requires approval by default)",
+    description: "Update a setting key's value",
     searchTerms: "settings update change set write value configuration",
   },
 };

--- a/src/routes/settings/sections/extensions/built-in-extensions-utils.ts
+++ b/src/routes/settings/sections/extensions/built-in-extensions-utils.ts
@@ -67,6 +67,21 @@ export const BUILT_IN_TOOLS: Record<
     description: "Delegate focused work to a streamed subagent",
     searchTerms: "subagent delegate nested agent parallel work",
   },
+  listSettings: {
+    name: "List Settings",
+    description: "List all available configuration setting keys",
+    searchTerms: "settings list keys config configuration options",
+  },
+  getSetting: {
+    name: "Get Setting",
+    description: "Get the current value and possible options of a specific setting",
+    searchTerms: "settings get value options inspect configuration",
+  },
+  updateSetting: {
+    name: "Update Setting",
+    description: "Update a setting key's value (requires approval by default)",
+    searchTerms: "settings update change set write value configuration",
+  },
 };
 
 export const TOOL_IDS = Object.keys(BUILT_IN_TOOLS) as ToolId[];


### PR DESCRIPTION
Allow AgentOne to read and edit its own settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new settings-management AI tools: listSettings, getSetting, and updateSetting (with optional approval workflows).
  * Updated conversation rendering to properly display these tool calls across all relevant tool states (approval, streaming, success, denied, and error).
  * Enhanced settings support with key inspectability/validation and atom-backed retrieval/update of setting values.
* **Documentation**
  * Updated the application prompt to describe when settings tools are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->